### PR TITLE
install swag instead of updating it in the go deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ check:
 	golangci-lint run --enable-all ./cmd/... ./pkg/...
 
 docs/docs.go: 
-	swag -v || go get -u github.com/swaggo/swag/cmd/swag
+	swag -v || go install github.com/swaggo/swag/cmd/swag
 	swag init -g pkg/api/routes.go
 
 .PHONY: doc


### PR DESCRIPTION
go get -u <package> does an update of the go.mod and go.sum files; go
install <package> installs the binary at that location.

It seems the intent of this line in the makefile is to install swag if it
doesn't exist based on the ||, so let's actually install it, instead of
just updating the local deps.

This also has the advantage of not immediately generating a diff when
someone doesn't have swag installed.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>