### PR TITLE
Issue 42 - Fixing issues with upgrading to golangci-lint 1.21.0

### DIFF
--- a/.bazel/golangcilint.yaml
+++ b/.bazel/golangcilint.yaml
@@ -5,6 +5,7 @@ run:
 
 linters:
   enable-all: true
+  disable: funlen,godox,gocognit
 
 output:
   format: colored-line-number

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ test:
 
 .PHONY: check
 check: .bazel/golangcilint.yaml
-	golangci-lint --version || curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.17.1
-	golangci-lint  --config .bazel/golangcilint.yaml run --enable-all ./cmd/... ./pkg/...
+	golangci-lint --version || curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.21.0
+	golangci-lint --config .bazel/golangcilint.yaml run --enable-all ./cmd/... ./pkg/...
 
 docs/docs.go: 
 	swag -v || go install github.com/swaggo/swag/cmd/swag

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -82,13 +82,18 @@ func (c *Config) Sanitize() *Config {
 		if err := deepcopy.Copy(s, c); err != nil {
 			panic(err)
 		}
+
 		s.HTTP.Auth.LDAP = &LDAPConfig{}
+
 		if err := deepcopy.Copy(s.HTTP.Auth.LDAP, c.HTTP.Auth.LDAP); err != nil {
 			panic(err)
 		}
+
 		s.HTTP.Auth.LDAP.BindPassword = "******"
+
 		return s
 	}
+
 	return c
 }
 
@@ -101,5 +106,6 @@ func (c *Config) Validate(log log.Logger) error {
 			return errors.ErrLDAPConfig
 		}
 	}
+
 	return nil
 }

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -40,6 +40,7 @@ func (c *Controller) Run() error {
 	engine := mux.NewRouter()
 	engine.Use(log.SessionLogger(c.Log), handlers.RecoveryHandler(handlers.RecoveryLogger(c.Log),
 		handlers.PrintRecoveryStack(false)))
+
 	c.Router = engine
 	_ = NewRouteHandler(c)
 
@@ -66,10 +67,13 @@ func (c *Controller) Run() error {
 			if err != nil {
 				panic(err)
 			}
+
 			caCertPool := x509.NewCertPool()
+
 			if !caCertPool.AppendCertsFromPEM(caCert) {
 				panic(errors.ErrBadCACert)
 			}
+
 			server.TLSConfig = &tls.Config{
 				ClientAuth:               clientAuth,
 				ClientCAs:                caCertPool,
@@ -81,5 +85,6 @@ func (c *Controller) Run() error {
 
 		return server.ServeTLS(l, c.Config.HTTP.TLS.Cert, c.Config.HTTP.TLS.Key)
 	}
+
 	return server.Serve(l)
 }

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -637,21 +637,25 @@ func newTestLDAPServer() *testLDAPServer {
 	server.SearchFunc("", l)
 	l.server = server
 	l.quitCh = quitCh
+
 	return l
 }
 
 func (l *testLDAPServer) Start() {
 	addr := fmt.Sprintf("%s:%d", LDAPAddress, LDAPPort)
+
 	go func() {
 		if err := l.server.ListenAndServe(addr); err != nil {
 			panic(err)
 		}
 	}()
+
 	for {
 		_, err := net.Dial("tcp", addr)
 		if err == nil {
 			break
 		}
+
 		time.Sleep(10 * time.Millisecond)
 	}
 }
@@ -664,10 +668,12 @@ func (l *testLDAPServer) Bind(bindDN, bindSimplePw string, conn net.Conn) (vldap
 	if bindDN == "" || bindSimplePw == "" {
 		return vldap.LDAPResultInappropriateAuthentication, errors.New("ldap: bind creds required")
 	}
+
 	if (bindDN == LDAPBindDN && bindSimplePw == LDAPBindPassword) ||
 		(bindDN == fmt.Sprintf("cn=%s,%s", username, LDAPBaseDN) && bindSimplePw == passphrase) {
 		return vldap.LDAPResultSuccess, nil
 	}
+
 	return vldap.LDAPResultInvalidCredentials, errors.New("ldap: invalid credentials")
 }
 
@@ -682,6 +688,7 @@ func (l *testLDAPServer) Search(boundDN string, req vldap.SearchRequest,
 			ResultCode: vldap.LDAPResultSuccess,
 		}, nil
 	}
+
 	return vldap.ServerSearchResult{}, nil
 }
 

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -35,7 +35,6 @@ const (
 )
 
 func NewError(code ErrorCode, detail ...interface{}) Error {
-
 	var errMap = map[ErrorCode]Error{
 		BLOB_UNKNOWN: {
 			Message: "blob unknown to registry",
@@ -138,5 +137,6 @@ func NewError(code ErrorCode, detail ...interface{}) Error {
 
 	e.Code = code
 	e.Detail = detail
+
 	return e
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -43,6 +43,7 @@ type RouteHandler struct {
 func NewRouteHandler(c *Controller) *RouteHandler {
 	rh := &RouteHandler{c: c}
 	rh.SetupRoutes()
+
 	return rh
 }
 
@@ -116,6 +117,7 @@ type ImageTags struct {
 func (rh *RouteHandler) ListTags(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -145,6 +147,7 @@ func (rh *RouteHandler) ListTags(w http.ResponseWriter, r *http.Request) {
 func (rh *RouteHandler) CheckManifest(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -165,6 +168,7 @@ func (rh *RouteHandler) CheckManifest(w http.ResponseWriter, r *http.Request) {
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			WriteJSON(w, http.StatusInternalServerError, NewError(MANIFEST_INVALID, map[string]string{"reference": reference}))
 		}
+
 		return
 	}
 
@@ -193,6 +197,7 @@ type ImageManifest struct {
 func (rh *RouteHandler) GetManifest(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -217,6 +222,7 @@ func (rh *RouteHandler) GetManifest(w http.ResponseWriter, r *http.Request) {
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
 		return
 	}
 
@@ -240,6 +246,7 @@ func (rh *RouteHandler) GetManifest(w http.ResponseWriter, r *http.Request) {
 func (rh *RouteHandler) UpdateManifest(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -278,6 +285,7 @@ func (rh *RouteHandler) UpdateManifest(w http.ResponseWriter, r *http.Request) {
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
 		return
 	}
 
@@ -298,6 +306,7 @@ func (rh *RouteHandler) UpdateManifest(w http.ResponseWriter, r *http.Request) {
 func (rh *RouteHandler) DeleteManifest(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -320,6 +329,7 @@ func (rh *RouteHandler) DeleteManifest(w http.ResponseWriter, r *http.Request) {
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
 		return
 	}
 
@@ -339,6 +349,7 @@ func (rh *RouteHandler) DeleteManifest(w http.ResponseWriter, r *http.Request) {
 func (rh *RouteHandler) CheckBlob(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -365,6 +376,7 @@ func (rh *RouteHandler) CheckBlob(w http.ResponseWriter, r *http.Request) {
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
 		return
 	}
 
@@ -391,6 +403,7 @@ func (rh *RouteHandler) CheckBlob(w http.ResponseWriter, r *http.Request) {
 func (rh *RouteHandler) GetBlob(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -417,6 +430,7 @@ func (rh *RouteHandler) GetBlob(w http.ResponseWriter, r *http.Request) {
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
 		return
 	}
 
@@ -438,6 +452,7 @@ func (rh *RouteHandler) GetBlob(w http.ResponseWriter, r *http.Request) {
 func (rh *RouteHandler) DeleteBlob(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -462,6 +477,7 @@ func (rh *RouteHandler) DeleteBlob(w http.ResponseWriter, r *http.Request) {
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
 		return
 	}
 
@@ -483,6 +499,7 @@ func (rh *RouteHandler) DeleteBlob(w http.ResponseWriter, r *http.Request) {
 func (rh *RouteHandler) CreateBlobUpload(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -497,6 +514,7 @@ func (rh *RouteHandler) CreateBlobUpload(w http.ResponseWriter, r *http.Request)
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
 		return
 	}
 
@@ -521,6 +539,7 @@ func (rh *RouteHandler) CreateBlobUpload(w http.ResponseWriter, r *http.Request)
 func (rh *RouteHandler) GetBlobUpload(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -547,6 +566,7 @@ func (rh *RouteHandler) GetBlobUpload(w http.ResponseWriter, r *http.Request) {
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
 		return
 	}
 
@@ -575,10 +595,12 @@ func (rh *RouteHandler) PatchBlobUpload(w http.ResponseWriter, r *http.Request) 
 	rh.c.Log.Info().Interface("headers", r.Header).Msg("request headers")
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
+
 	uuid, ok := vars["uuid"]
 	if !ok || uuid == "" {
 		w.WriteHeader(http.StatusNotFound)
@@ -586,10 +608,13 @@ func (rh *RouteHandler) PatchBlobUpload(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var err error
+
 	var contentLength int64
+
 	if contentLength, err = strconv.ParseInt(r.Header.Get("Content-Length"), 10, 64); err != nil {
 		rh.c.Log.Warn().Str("actual", r.Header.Get("Content-Length")).Msg("invalid content length")
 		w.WriteHeader(http.StatusBadRequest)
+
 		return
 	}
 
@@ -597,6 +622,7 @@ func (rh *RouteHandler) PatchBlobUpload(w http.ResponseWriter, r *http.Request) 
 	if contentRange == "" {
 		rh.c.Log.Warn().Str("actual", r.Header.Get("Content-Range")).Msg("invalid content range")
 		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+
 		return
 	}
 
@@ -609,6 +635,7 @@ func (rh *RouteHandler) PatchBlobUpload(w http.ResponseWriter, r *http.Request) 
 	if contentType := r.Header.Get("Content-Type"); contentType != "application/octet-stream" {
 		rh.c.Log.Warn().Str("actual", contentType).Str("expected", "application/octet-stream").Msg("invalid media type")
 		w.WriteHeader(http.StatusUnsupportedMediaType)
+
 		return
 	}
 
@@ -625,6 +652,7 @@ func (rh *RouteHandler) PatchBlobUpload(w http.ResponseWriter, r *http.Request) 
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
 		return
 	}
 
@@ -652,6 +680,7 @@ func (rh *RouteHandler) PatchBlobUpload(w http.ResponseWriter, r *http.Request) 
 func (rh *RouteHandler) UpdateBlobUpload(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -668,14 +697,18 @@ func (rh *RouteHandler) UpdateBlobUpload(w http.ResponseWriter, r *http.Request)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
+
 	digest := digests[0]
 
 	contentPresent := true
 	contentLen, err := strconv.ParseInt(r.Header.Get("Content-Length"), 10, 64)
+
 	if err != nil || contentLen == 0 {
 		contentPresent = false
 	}
+
 	contentRangePresent := true
+
 	if r.Header.Get("Content-Range") == "" {
 		contentRangePresent = false
 	}
@@ -698,10 +731,12 @@ func (rh *RouteHandler) UpdateBlobUpload(w http.ResponseWriter, r *http.Request)
 		contentRange := r.Header.Get("Content-Range")
 		if contentRange == "" { // monolithic upload
 			from = 0
+
 			if contentLen == 0 {
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
+
 			to = contentLen
 		} else if from, to, err = getContentRange(r); err != nil { // finish chunked upload
 			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
@@ -721,6 +756,7 @@ func (rh *RouteHandler) UpdateBlobUpload(w http.ResponseWriter, r *http.Request)
 				rh.c.Log.Error().Err(err).Msg("unexpected error")
 				w.WriteHeader(http.StatusInternalServerError)
 			}
+
 			return
 		}
 	}
@@ -740,6 +776,7 @@ func (rh *RouteHandler) UpdateBlobUpload(w http.ResponseWriter, r *http.Request)
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
 		return
 	}
 
@@ -763,6 +800,7 @@ func (rh *RouteHandler) UpdateBlobUpload(w http.ResponseWriter, r *http.Request)
 func (rh *RouteHandler) DeleteBlobUpload(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
+
 	if !ok || name == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -784,6 +822,7 @@ func (rh *RouteHandler) DeleteBlobUpload(w http.ResponseWriter, r *http.Request)
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
 		return
 	}
 
@@ -820,25 +859,31 @@ func getContentRange(r *http.Request) (int64 /* from */, int64 /* to */, error) 
 	contentRange := r.Header.Get("Content-Range")
 	tokens := strings.Split(contentRange, "-")
 	from, err := strconv.ParseInt(tokens[0], 10, 64)
+
 	if err != nil {
 		return -1, -1, errors.ErrBadUploadRange
 	}
+
 	to, err := strconv.ParseInt(tokens[1], 10, 64)
 	if err != nil {
 		return -1, -1, errors.ErrBadUploadRange
 	}
+
 	if from > to {
 		return -1, -1, errors.ErrBadUploadRange
 	}
+
 	return from, to, nil
 }
 
 func WriteJSON(w http.ResponseWriter, status int, data interface{}) {
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	body, err := json.Marshal(data)
+
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
+
 	WriteData(w, status, DefaultMediaType, body)
 }
 
@@ -853,6 +898,7 @@ func WriteDataFromReader(w http.ResponseWriter, status int, length int64, mediaT
 	w.Header().Set("Content-Length", strconv.FormatInt(length, 10))
 
 	const maxSize = 10 * 1024 * 1024
+
 	for {
 		size, err := io.CopyN(w, reader, maxSize)
 		if size == 0 {
@@ -860,6 +906,7 @@ func WriteDataFromReader(w http.ResponseWriter, status int, length int64, mediaT
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
+
 			break
 		}
 	}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -80,6 +80,7 @@ func NewRootCmd() *cobra.Command {
 
 	gcCmd.Flags().StringVarP(&config.Storage.RootDirectory, "storage-root-dir", "r", "",
 		"Use specified directory for filestore backing image data")
+
 	_ = gcCmd.MarkFlagRequired("storage-root-dir")
 	gcCmd.Flags().BoolVarP(&gcDelUntagged, "delete-untagged", "m", false,
 		"delete manifests that are not currently referenced via tag")
@@ -106,14 +107,18 @@ func NewRootCmd() *cobra.Command {
 
 	complianceCmd.Flags().StringVarP(&complianceConfig.Address, "address", "H", "",
 		"Registry server address")
+
 	if err := complianceCmd.MarkFlagRequired("address"); err != nil {
 		panic(err)
 	}
+
 	complianceCmd.Flags().StringVarP(&complianceConfig.Port, "port", "P", "",
 		"Registry server port")
+
 	if err := complianceCmd.MarkFlagRequired("port"); err != nil {
 		panic(err)
 	}
+
 	complianceCmd.Flags().StringVarP(&complianceConfig.Version, "version", "V", "all",
 		"OCI dist-spec version to check")
 

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestUsage(t *testing.T) {
 	oldArgs := os.Args
+
 	defer func() { os.Args = oldArgs }()
 
 	Convey("Test usage", t, func(c C) {
@@ -28,6 +29,7 @@ func TestUsage(t *testing.T) {
 
 func TestServe(t *testing.T) {
 	oldArgs := os.Args
+
 	defer func() { os.Args = oldArgs }()
 
 	Convey("Test serve help", t, func(c C) {
@@ -64,6 +66,7 @@ func TestServe(t *testing.T) {
 
 func TestGC(t *testing.T) {
 	oldArgs := os.Args
+
 	defer func() { os.Args = oldArgs }()
 
 	Convey("Test gc", t, func(c C) {

--- a/pkg/compliance/v1_0_0/check_test.go
+++ b/pkg/compliance/v1_0_0/check_test.go
@@ -29,11 +29,13 @@ func TestMain(m *testing.M) {
 	config.HTTP.Port = Port
 	c := api.NewController(config)
 	dir, err := ioutil.TempDir("", "oci-repo-test")
+
 	if err != nil {
 		panic(err)
 	}
 	//defer os.RemoveAll(dir)
 	c.Config.Storage.RootDirectory = dir
+
 	go func() {
 		// this blocks
 		if err := c.Run(); err != nil {
@@ -42,16 +44,20 @@ func TestMain(m *testing.M) {
 	}()
 
 	BaseURL := fmt.Sprintf("http://%s:%s", Address, Port)
+
 	for {
 		// poll until ready
 		resp, _ := resty.R().Get(BaseURL)
 		if resp.StatusCode() == 404 {
 			break
 		}
+
 		time.Sleep(100 * time.Millisecond)
 	}
+
 	status := m.Run()
 	ctx := context.Background()
 	_ = c.Server.Shutdown(ctx)
+
 	os.Exit(status)
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -21,11 +21,15 @@ func (l Logger) Println(v ...interface{}) {
 func NewLogger(level string, output string) Logger {
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 	lvl, err := zerolog.ParseLevel(level)
+
 	if err != nil {
 		panic(err)
 	}
+
 	zerolog.SetGlobalLevel(lvl)
+
 	var log zerolog.Logger
+
 	if output == "" {
 		log = zerolog.New(os.Stdout)
 	} else {
@@ -35,6 +39,7 @@ func NewLogger(level string, output string) Logger {
 		}
 		log = zerolog.New(file)
 	}
+
 	return Logger{Logger: log.With().Timestamp().Logger()}
 }
 
@@ -53,13 +58,16 @@ func (w *statusWriter) Write(b []byte) (int, error) {
 	if w.status == 0 {
 		w.status = 200
 	}
+
 	n, err := w.ResponseWriter.Write(b)
 	w.length += n
+
 	return n, err
 }
 
 func SessionLogger(log Logger) mux.MiddlewareFunc {
 	l := log.With().Str("module", "http").Logger()
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Start timer

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -21,6 +21,7 @@ func TestAPIs(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+
 	defer os.RemoveAll(dir)
 
 	il := storage.NewImageStore(dir, log.Logger{Logger: zerolog.New(os.Stdout)})


### PR DESCRIPTION
Using go 1.13.5 caused golangci-lint to break.
Upgrading to 1.21.0 introduced lots of new lint findings.
Fixed everything except I add ignores for the following lint rules:
  disable: funlen,godox,gocognit