### PR TITLE
routes: handle "mount blob" to remain compliant

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -505,6 +505,18 @@ func (rh *RouteHandler) CreateBlobUpload(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// blob mounts not allowed since we don't have access control yet, and this
+	// may be a uncommon use case, but remain compliant
+	if _, ok := r.URL.Query()["mount"]; ok {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	if _, ok := r.URL.Query()["from"]; ok {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
 	u, err := rh.c.ImageStore.NewBlobUpload(name)
 	if err != nil {
 		switch err {

--- a/pkg/compliance/v1_0_0/check.go
+++ b/pkg/compliance/v1_0_0/check.go
@@ -377,6 +377,14 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 			So(resp.Header().Get("Content-Length"), ShouldEqual, "0")
 		})
 
+		Convey("Mount blobs", func() {
+			Print("\nMount blobs from another repository")
+			// create a upload
+			resp, err := resty.R().Post(baseURL + "/v2/repo/blobs/uploads/?digest=\"abc\"&&from=\"xyz\"")
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, 405)
+		})
+
 		Convey("Manifests", func() {
 			Print("\nManifests")
 			// create a blob/layer


### PR DESCRIPTION
"mount blob" was the only feature we didn't handle.
We don't fully support it yet because we don't have access control
support, but at least handle it and return something sane to remain
compliant.