### PR TITLE
routes: be more paranoid

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -920,7 +920,7 @@ func WriteDataFromReader(w http.ResponseWriter, status int, length int64, mediaT
 			break
 		} else if err != nil {
 			// other kinds of intermittent errors can occur, e.g, io.ErrShortWrite
-			logger.Error().Err(err).Msg("copying data into http response")
+			logger.Panic().Err(err).Msg("copying data into http response")
 		}
 	}
 }


### PR DESCRIPTION
once we have an non-EOF error in this path, not clear if we can really
recover.