### PR TITLE
manifest can be deleted only by digest and not tag

### DIFF
--- a/pkg/compliance/v1_0_0/check.go
+++ b/pkg/compliance/v1_0_0/check.go
@@ -467,8 +467,12 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 			So(resp.StatusCode(), ShouldEqual, 200)
 			So(resp.Body(), ShouldNotBeEmpty)
 
-			// delete manifest
+			// delete manifest by tag should fail
 			resp, err = resty.R().Delete(baseURL + "/v2/repo7/manifests/test:1.0")
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, 404)
+			// delete manifest by digest
+			resp, err = resty.R().Delete(baseURL + "/v2/repo7/manifests/" + digest.String())
 			So(err, ShouldBeNil)
 			So(resp.StatusCode(), ShouldEqual, 202)
 			// delete again should fail

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -443,6 +443,12 @@ func (is *ImageStore) DeleteImageManifest(repo string, reference string) error {
 		return errors.ErrRepoNotFound
 	}
 
+	_, err := godigest.Parse(reference)
+	if err != nil {
+		is.log.Error().Err(err).Msg("invalid reference")
+		return errors.ErrManifestNotFound
+	}
+
 	buf, err := ioutil.ReadFile(path.Join(dir, "index.json"))
 
 	if err != nil {

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -115,6 +115,9 @@ func TestAPIs(t *testing.T) {
 					_, _, _, err = il.GetImageManifest("test", d.String())
 					So(err, ShouldBeNil)
 
+					err = il.DeleteImageManifest("test", "1.0")
+					So(err, ShouldNotBeNil)
+
 					err = il.DeleteImageManifest("test", d.String())
 					So(err, ShouldBeNil)
 


### PR DESCRIPTION
Fixes issue #67.

As per dist spec, DELETE of a image manifest can only be done with
digest as <reference> param. Previously, tags were being allowed as
well. This is not conformant to the spec.