### PR TITLE
routes: CheckManifest should return 404 when repo is unknown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ debug: doc
 .PHONY: test
 test:
 	$(shell mkdir -p test/data; cd test/data; ../scripts/gen_certs.sh; cd ${TOP_LEVEL})
-	go test -v -race -cover -coverprofile=coverage.txt -covermode=atomic ./...
+	go test -v -race -cover -coverpkg ./... -coverprofile=coverage.txt -covermode=atomic ./...
 
 .PHONY: covhtml
 covhtml:

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -242,6 +242,9 @@ func (rh *RouteHandler) CheckManifest(w http.ResponseWriter, r *http.Request) {
 	_, digest, _, err := rh.c.ImageStore.GetImageManifest(name, reference)
 	if err != nil {
 		switch err {
+		case errors.ErrRepoNotFound:
+			WriteJSON(w, http.StatusNotFound,
+				NewErrorList(NewError(NAME_UNKNOWN, map[string]string{"reference": reference})))
 		case errors.ErrManifestNotFound:
 			WriteJSON(w, http.StatusNotFound,
 				NewErrorList(NewError(MANIFEST_UNKNOWN, map[string]string{"reference": reference})))

--- a/pkg/compliance/v1_0_0/check.go
+++ b/pkg/compliance/v1_0_0/check.go
@@ -474,6 +474,12 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 			So(resp.Header().Get("Content-Length"), ShouldEqual, "0")
 			So(resp.Header().Get(api.DistContentDigestKey), ShouldNotBeEmpty)
 
+			// check a non-existent manifest
+			resp, err = resty.R().SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
+				SetBody(content).Head(baseURL + "/v2/unknown/manifests/test:1.0")
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, 404)
+
 			// create a manifest
 			m := ispec.Manifest{Layers: []ispec.Descriptor{{Digest: digest}}}
 			content, err = json.Marshal(m)


### PR DESCRIPTION
Previously, CheckManifest() was not checking for repo not found
condition and would default to 500 status code.

Add the check now to return 404.

Fixes issue #74