### PR TITLE
conformance: fix http status codes for MANIFEST DELETE failures.

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -416,10 +416,10 @@ func (rh *RouteHandler) DeleteManifest(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch err {
 		case errors.ErrRepoNotFound:
-			WriteJSON(w, http.StatusNotFound,
+			WriteJSON(w, http.StatusBadRequest,
 				NewErrorList(NewError(NAME_UNKNOWN, map[string]string{"name": name})))
 		case errors.ErrManifestNotFound:
-			WriteJSON(w, http.StatusNotFound,
+			WriteJSON(w, http.StatusBadRequest,
 				NewErrorList(NewError(MANIFEST_UNKNOWN, map[string]string{"reference": reference})))
 		default:
 			rh.c.Log.Error().Err(err).Msg("unexpected error")

--- a/pkg/compliance/v1_0_0/check.go
+++ b/pkg/compliance/v1_0_0/check.go
@@ -531,7 +531,7 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 			// delete manifest by tag should fail
 			resp, err = resty.R().Delete(baseURL + "/v2/repo7/manifests/test:1.0")
 			So(err, ShouldBeNil)
-			So(resp.StatusCode(), ShouldEqual, 404)
+			So(resp.StatusCode(), ShouldEqual, 400)
 			// delete manifest by digest
 			resp, err = resty.R().Delete(baseURL + "/v2/repo7/manifests/" + digest.String())
 			So(err, ShouldBeNil)
@@ -543,7 +543,7 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 			// delete again should fail
 			resp, err = resty.R().Delete(baseURL + "/v2/repo7/manifests/" + digest.String())
 			So(err, ShouldBeNil)
-			So(resp.StatusCode(), ShouldEqual, 404)
+			So(resp.StatusCode(), ShouldEqual, 400)
 
 			// check/get by tag
 			resp, err = resty.R().Head(baseURL + "/v2/repo7/manifests/test:1.0")


### PR DESCRIPTION
Previously returning 404s as failure code, dist-spec says 400s.