### PR TITLE
compat: when in "world-readable" mode, return the WWW-Authenticate

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -120,6 +120,18 @@ func (rh *RouteHandler) SetupRoutes() {
 // @Success 200 {string} string	"ok"
 func (rh *RouteHandler) CheckVersionSupport(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(DistAPIVersion, "registry/2.0")
+	// NOTE: compatibility workaround - return this header in "allowed-read" mode to allow for clients to
+	// work correctly
+	if rh.c.Config.HTTP.AllowReadAccess {
+		if rh.c.Config.HTTP.Auth != nil {
+			if rh.c.Config.HTTP.Auth.Bearer != nil {
+				w.Header().Set("WWW-Authenticate", fmt.Sprintf("bearer realm=%s", rh.c.Config.HTTP.Auth.Bearer.Realm))
+			} else {
+				w.Header().Set("WWW-Authenticate", fmt.Sprintf("basic realm=%s", rh.c.Config.HTTP.Realm))
+			}
+		}
+	}
+
 	WriteData(w, http.StatusOK, "application/json", []byte{})
 }
 


### PR DESCRIPTION
header

containers/image is the dominant client library to interact with
registries.

It detects which authentication to use based on the WWW-Authenticate
header returned when pinging "/v2/" end-point. If we didn't return this
header, then creds are not used for other write-protected end-points.
Hence, the compatibility fix.