### PR TITLE
helm: relax Content-Type checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 * Conforms to [OCI distribution spec](https://github.com/opencontainers/distribution-spec) APIs [![zot](https://github.com/bloodorangeio/oci-distribution-conformance-results/workflows/zot/badge.svg)](https://oci.bloodorange.io/results/report-zot.html) [![zot w. auth](https://github.com/bloodorangeio/oci-distribution-conformance-results/workflows/zot-auth/badge.svg)](https://oci.bloodorange.io/results/report-zot-auth.html)
 * Uses [OCI storage layout](https://github.com/opencontainers/image-spec/blob/master/image-layout.md) for storage layout
+* Supports [helm charts](https://helm.sh/docs/topics/registries/)
 * Currently suitable for on-prem deployments (e.g. colocated with Kubernetes)
 * TLS support
 * Authentication via:

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -957,11 +957,6 @@ func (rh *RouteHandler) UpdateBlobUpload(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		if r.Header.Get("Content-Type") != BinaryMediaType {
-			w.WriteHeader(http.StatusUnsupportedMediaType)
-			return
-		}
-
 		_, err = rh.c.ImageStore.PutBlobChunk(name, sessionID, from, to, r.Body)
 		if err != nil {
 			switch err {
@@ -984,10 +979,6 @@ func (rh *RouteHandler) UpdateBlobUpload(w http.ResponseWriter, r *http.Request)
 	}
 
 finish:
-	if r.Header.Get("Content-Type") != BinaryMediaType {
-		w.WriteHeader(http.StatusUnsupportedMediaType)
-		return
-	}
 	// blob chunks already transferred, just finish
 	if err := rh.c.ImageStore.FinishBlobUpload(name, sessionID, r.Body, digest); err != nil {
 		switch err {

--- a/pkg/compliance/v1_0_0/check.go
+++ b/pkg/compliance/v1_0_0/check.go
@@ -144,7 +144,7 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 			// without the Content-Length should fail
 			resp, err = resty.R().SetQueryParam("digest", digest.String()).Put(loc)
 			So(err, ShouldBeNil)
-			So(resp.StatusCode(), ShouldEqual, 415)
+			So(resp.StatusCode(), ShouldEqual, 400)
 			// without any data to send, should fail
 			resp, err = resty.R().SetQueryParam("digest", digest.String()).
 				SetHeader("Content-Type", "application/octet-stream").Put(loc)
@@ -237,7 +237,7 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 			// without the Content-Length should fail
 			resp, err = resty.R().SetQueryParam("digest", digest.String()).Put(loc)
 			So(err, ShouldBeNil)
-			So(resp.StatusCode(), ShouldEqual, 415)
+			So(resp.StatusCode(), ShouldEqual, 400)
 			// without any data to send, should fail
 			resp, err = resty.R().SetQueryParam("digest", digest.String()).
 				SetHeader("Content-Type", "application/octet-stream").Put(loc)


### PR DESCRIPTION
OCI registries are moving towards a more generic artifact storage
mechanism. In short-term, at the very least support helm charts.