### PR TITLE
dedupe: record relative path for cache entries

### DIFF
--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -3,6 +3,7 @@ package storage_test
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/anuvu/zot/errors"
@@ -33,7 +34,7 @@ func TestCache(t *testing.T) {
 		b := c.HasBlob("key", "value")
 		So(b, ShouldBeFalse)
 
-		err = c.PutBlob("key", "value")
+		err = c.PutBlob("key", path.Join(dir, "value"))
 		So(err, ShouldBeNil)
 
 		b = c.HasBlob("key", "value")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -849,6 +849,8 @@ retry:
 		}
 		is.log.Debug().Str("src", src).Str("dst", dst).Msg("dedupe: rename")
 	} else {
+		dstRecord = path.Join(is.rootDir, dstRecord)
+
 		dstRecordFi, err := os.Stat(dstRecord)
 		if err != nil {
 			is.log.Error().Err(err).Str("blobPath", dstRecord).Msg("dedupe: unable to stat")


### PR DESCRIPTION
In a production use case we found that the actual rootdir can be moved.
Currently, cache entries for dedupe record the full blob path which
doesn't work in the move use case.

Only for dedupe cache entries, record relative blob paths.