### PR TITLE
fix: the bug when htpasswd has multiple creds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test/data/
 coverage.html
 tags
 vendor/
+.vscode/

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -141,15 +141,16 @@ func basicAuthHandler(c *Controller) mux.MiddlewareFunc {
 			if err != nil {
 				panic(err)
 			}
+			defer f.Close()
 
-			for {
-				r := bufio.NewReader(f)
-				line, err := r.ReadString('\n')
-				if err != nil {
-					break
+			scanner := bufio.NewScanner(f)
+
+			for scanner.Scan() {
+				line := scanner.Text()
+				if strings.Contains(line, ":") {
+					tokens := strings.Split(scanner.Text(), ":")
+					credMap[tokens[0]] = tokens[1]
 				}
-				tokens := strings.Split(line, ":")
-				credMap[tokens[0]] = tokens[1]
 			}
 		}
 	}


### PR DESCRIPTION
earlier, when you had more than one creds in htpasswd file separated by newline, it used to only read the first cred in the file and ignore the rest.