### PR TITLE
auth: support a read-only mode

### DIFF
--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -91,6 +91,12 @@ func basicAuthHandler(c *Controller) mux.MiddlewareFunc {
 					authFail(w, realm, 5)
 					return
 				}
+
+				if (r.Method != http.MethodGet && r.Method != http.MethodHead) && c.Config.HTTP.ReadOnly {
+					// Reject modification requests in read-only mode
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
 				// Process request
 				next.ServeHTTP(w, r)
 			})
@@ -172,6 +178,12 @@ func basicAuthHandler(c *Controller) mux.MiddlewareFunc {
 			if (r.Method == http.MethodGet || r.Method == http.MethodHead) && c.Config.HTTP.AllowReadAccess {
 				// Process request
 				next.ServeHTTP(w, r)
+				return
+			}
+
+			if (r.Method != http.MethodGet && r.Method != http.MethodHead) && c.Config.HTTP.ReadOnly {
+				// Reject modification requests in read-only mode
+				w.WriteHeader(http.StatusMethodNotAllowed)
 				return
 			}
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -46,6 +46,7 @@ type HTTPConfig struct {
 	Auth            *AuthConfig
 	Realm           string
 	AllowReadAccess bool `mapstructure:",omitempty"`
+	ReadOnly        bool `mapstructure:",omitempty"`
 }
 
 type LDAPConfig struct {


### PR DESCRIPTION
This is useful if we want to roll out experimental versions of zot
pointing to some storage shared with another zot instance.

Also, when under storage full conditions, will be useful to turn on this
flag to prevent further writes.