### PR TITLE
cli: move client-only code out of the server flow

### DIFF
--- a/cmd/zot/main.go
+++ b/cmd/zot/main.go
@@ -2,20 +2,12 @@ package main
 
 import (
 	"os"
-	"path"
 
 	"github.com/anuvu/zot/pkg/cli"
 )
 
 func main() {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		panic(err)
-	}
-
-	configPath := path.Join(home + "/.zot")
-
-	if err := cli.NewRootCmd(configPath).Execute(); err != nil {
+	if err := cli.NewRootCmd().Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/zot/main_test.go
+++ b/cmd/zot/main_test.go
@@ -1,7 +1,6 @@
 package main_test
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"github.com/anuvu/zot/pkg/api"
@@ -15,8 +14,7 @@ func TestIntegration(t *testing.T) {
 		c := api.NewController(config)
 		So(c, ShouldNotBeNil)
 
-		tempFile, _ := ioutil.TempFile("", "tmp-")
-		cl := cli.NewRootCmd(tempFile.Name())
+		cl := cli.NewRootCmd()
 		So(cl, ShouldNotBeNil)
 
 		So(cl.Execute(), ShouldBeNil)

--- a/pkg/cli/config_cmd.go
+++ b/pkg/cli/config_cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -16,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewConfigCommand(configPath string) *cobra.Command {
+func NewConfigCommand() *cobra.Command {
 	var isListing bool
 
 	var isReset bool
@@ -28,6 +29,12 @@ func NewConfigCommand(configPath string) *cobra.Command {
 		Long:    `Configure default parameters for CLI`,
 		Args:    cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				panic(err)
+			}
+
+			configPath := path.Join(home + "/.zot")
 			switch len(args) {
 			case noArgs:
 				if isListing { // zot config -l
@@ -83,20 +90,26 @@ func NewConfigCommand(configPath string) *cobra.Command {
 	configCmd.Flags().BoolVarP(&isListing, "list", "l", false, "List configurations")
 	configCmd.Flags().BoolVar(&isReset, "reset", false, "Reset a variable value")
 	configCmd.SetUsageTemplate(configCmd.UsageTemplate() + supportedOptions)
-	configCmd.AddCommand(NewConfigAddCommand(configPath))
+	configCmd.AddCommand(NewConfigAddCommand())
 
 	return configCmd
 }
 
-func NewConfigAddCommand(configPath string) *cobra.Command {
+func NewConfigAddCommand() *cobra.Command {
 	var configAddCmd = &cobra.Command{
 		Use:   "add <config-name> <url>",
 		Short: "Add configuration for a zot URL",
 		Long:  `Configure CLI for interaction with a zot server`,
 		Args:  cobra.ExactArgs(twoArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				panic(err)
+			}
+
+			configPath := path.Join(home + "/.zot")
 			// zot config add <config-name> <url>
-			err := addConfig(configPath, args[0], args[1])
+			err = addConfig(configPath, args[0], args[1])
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/config_cmd_test.go
+++ b/pkg/cli/config_cmd_test.go
@@ -17,7 +17,7 @@ func TestConfigCmdBasics(t *testing.T) {
 		args := []string{"--help"}
 		configPath := makeConfigFile("showspinner = false")
 		defer os.Remove(configPath)
-		cmd := NewConfigCommand(configPath)
+		cmd := NewConfigCommand()
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -29,7 +29,7 @@ func TestConfigCmdBasics(t *testing.T) {
 			args[0] = "-h"
 			configPath := makeConfigFile("showspinner = false")
 			defer os.Remove(configPath)
-			cmd := NewConfigCommand(configPath)
+			cmd := NewConfigCommand()
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(ioutil.Discard)
@@ -44,7 +44,7 @@ func TestConfigCmdBasics(t *testing.T) {
 		args := []string{}
 		configPath := makeConfigFile("showspinner = false")
 		defer os.Remove(configPath)
-		cmd := NewConfigCommand(configPath)
+		cmd := NewConfigCommand()
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -60,7 +60,7 @@ func TestConfigCmdMain(t *testing.T) {
 		args := []string{"add", "configtest1", "https://test-url.com"}
 		file := makeConfigFile("")
 		defer os.Remove(file)
-		cmd := NewConfigCommand(file)
+		cmd := NewConfigCommand()
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -80,7 +80,7 @@ func TestConfigCmdMain(t *testing.T) {
 		args := []string{"add", "configtest1", "test..com"}
 		file := makeConfigFile("")
 		defer os.Remove(file)
-		cmd := NewConfigCommand(file)
+		cmd := NewConfigCommand()
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -94,7 +94,7 @@ func TestConfigCmdMain(t *testing.T) {
 		args := []string{"--list"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 		defer os.Remove(configPath)
-		cmd := NewConfigCommand(configPath)
+		cmd := NewConfigCommand()
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -107,7 +107,7 @@ func TestConfigCmdMain(t *testing.T) {
 			args := []string{"-l"}
 			configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 			defer os.Remove(configPath)
-			cmd := NewConfigCommand(configPath)
+			cmd := NewConfigCommand()
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(ioutil.Discard)
@@ -121,7 +121,7 @@ func TestConfigCmdMain(t *testing.T) {
 			args := []string{"-l"}
 			configPath := makeConfigFile(``)
 			defer os.Remove(configPath)
-			cmd := NewConfigCommand(configPath)
+			cmd := NewConfigCommand()
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(ioutil.Discard)
@@ -136,7 +136,7 @@ func TestConfigCmdMain(t *testing.T) {
 		args := []string{"configtest", "--list"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 		defer os.Remove(configPath)
-		cmd := NewConfigCommand(configPath)
+		cmd := NewConfigCommand()
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -150,7 +150,7 @@ func TestConfigCmdMain(t *testing.T) {
 			args := []string{"configtest", "-l"}
 			configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 			defer os.Remove(configPath)
-			cmd := NewConfigCommand(configPath)
+			cmd := NewConfigCommand()
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(ioutil.Discard)
@@ -165,7 +165,7 @@ func TestConfigCmdMain(t *testing.T) {
 			args := []string{"configtest", "-l"}
 			configPath := makeConfigFile(``)
 			defer os.Remove(configPath)
-			cmd := NewConfigCommand(configPath)
+			cmd := NewConfigCommand()
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(ioutil.Discard)
@@ -180,7 +180,7 @@ func TestConfigCmdMain(t *testing.T) {
 		args := []string{"configtest", "url"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 		defer os.Remove(configPath)
-		cmd := NewConfigCommand(configPath)
+		cmd := NewConfigCommand()
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -193,7 +193,7 @@ func TestConfigCmdMain(t *testing.T) {
 			args := []string{"configtest", "url"}
 			configPath := makeConfigFile(``)
 			defer os.Remove(configPath)
-			cmd := NewConfigCommand(configPath)
+			cmd := NewConfigCommand()
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -208,7 +208,7 @@ func TestConfigCmdMain(t *testing.T) {
 		args := []string{"configtest", "showspinner", "false"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com"}]}`)
 		defer os.Remove(configPath)
-		cmd := NewConfigCommand(configPath)
+		cmd := NewConfigCommand()
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -229,7 +229,7 @@ func TestConfigCmdMain(t *testing.T) {
 			args := []string{"configtest", "showspinner", "false"}
 			configPath := makeConfigFile(``)
 			defer os.Remove(configPath)
-			cmd := NewConfigCommand(configPath)
+			cmd := NewConfigCommand()
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(ioutil.Discard)
@@ -244,7 +244,7 @@ func TestConfigCmdMain(t *testing.T) {
 		args := []string{"configtest", "url", "https://new-url.com"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 		defer os.Remove(configPath)
-		cmd := NewConfigCommand(configPath)
+		cmd := NewConfigCommand()
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -267,7 +267,7 @@ func TestConfigCmdMain(t *testing.T) {
 		args := []string{"configtest", "showspinner", "--reset"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 		defer os.Remove(configPath)
-		cmd := NewConfigCommand(configPath)
+		cmd := NewConfigCommand()
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -289,7 +289,7 @@ func TestConfigCmdMain(t *testing.T) {
 		args := []string{"configtest", "url", "--reset"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 		defer os.Remove(configPath)
-		cmd := NewConfigCommand(configPath)
+		cmd := NewConfigCommand()
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)

--- a/pkg/cli/image_cmd.go
+++ b/pkg/cli/image_cmd.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path"
 	"strconv"
 	"time"
 
@@ -9,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewImageCommand(searchService ImageSearchService, configPath string) *cobra.Command {
+func NewImageCommand(searchService ImageSearchService) *cobra.Command {
 	searchImageParams := make(map[string]*string)
 
 	var servURL string
@@ -23,6 +25,12 @@ func NewImageCommand(searchService ImageSearchService, configPath string) *cobra
 		Short: "List hosted images",
 		Long:  `List images hosted on zot`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				panic(err)
+			}
+
+			configPath := path.Join(home + "/.zot")
 			if servURL == "" {
 				if len(args) > 0 {
 					urlFromConfig, err := getConfigValue(configPath, args[0], "url")
@@ -52,7 +60,7 @@ func NewImageCommand(searchService ImageSearchService, configPath string) *cobra
 				isSpinner = true
 			}
 
-			err := searchImage(cmd, searchImageParams, searchService, &servURL, &user, &outputFormat, isSpinner)
+			err = searchImage(cmd, searchImageParams, searchService, &servURL, &user, &outputFormat, isSpinner)
 
 			if err != nil {
 				cmd.SilenceUsage = true

--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -29,7 +30,7 @@ func TestSearchImageCmd(t *testing.T) {
 		args := []string{"--help"}
 		configPath := makeConfigFile("")
 		defer os.Remove(configPath)
-		cmd := NewImageCommand(new(mockService), configPath)
+		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -41,7 +42,7 @@ func TestSearchImageCmd(t *testing.T) {
 			args[0] = "-h"
 			configPath := makeConfigFile("")
 			defer os.Remove(configPath)
-			cmd := NewImageCommand(new(mockService), configPath)
+			cmd := NewImageCommand(new(mockService))
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(ioutil.Discard)
@@ -55,7 +56,7 @@ func TestSearchImageCmd(t *testing.T) {
 		args := []string{"imagetest", "--name", "dummyIdRandom"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 		defer os.Remove(configPath)
-		cmd := NewImageCommand(new(mockService), configPath)
+		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -68,7 +69,7 @@ func TestSearchImageCmd(t *testing.T) {
 		args := []string{"imagetest", "--url", "someUrl"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 		defer os.Remove(configPath)
-		cmd := NewImageCommand(new(mockService), configPath)
+		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -81,7 +82,7 @@ func TestSearchImageCmd(t *testing.T) {
 		args := []string{"imagetest", "--name", "dummyImageName", "--url", "invalidUrl"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 		defer os.Remove(configPath)
-		cmd := NewImageCommand(new(searchService), configPath)
+		cmd := NewImageCommand(new(searchService))
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -95,7 +96,7 @@ func TestSearchImageCmd(t *testing.T) {
 		args := []string{"imagetest", "--name", "dummyImageName", "--url", "http://localhost:99999"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 		defer os.Remove(configPath)
-		cmd := NewImageCommand(new(searchService), configPath)
+		cmd := NewImageCommand(new(searchService))
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -108,7 +109,7 @@ func TestSearchImageCmd(t *testing.T) {
 			args := []string{"imagetest", "--url", "http://localhost:99999"}
 			configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 			defer os.Remove(configPath)
-			cmd := NewImageCommand(new(searchService), configPath)
+			cmd := NewImageCommand(new(searchService))
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -122,7 +123,7 @@ func TestSearchImageCmd(t *testing.T) {
 		args := []string{"imagetest", "--name", "dummyImageName", "--url", "http://localhost:9999"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 		defer os.Remove(configPath)
-		cmd := NewImageCommand(new(searchService), configPath)
+		cmd := NewImageCommand(new(searchService))
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -137,7 +138,7 @@ func TestSearchImageCmd(t *testing.T) {
 		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 		defer os.Remove(configPath)
 
-		cmd := NewImageCommand(new(mockService), configPath)
+		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -153,7 +154,7 @@ func TestSearchImageCmd(t *testing.T) {
 		args := []string{"imagetest", "--name", "dummyImageName", "--url", "someUrlImage"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 		defer os.Remove(configPath)
-		imageCmd := NewImageCommand(new(mockService), configPath)
+		imageCmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
 		imageCmd.SetOut(buff)
 		imageCmd.SetErr(ioutil.Discard)
@@ -168,7 +169,7 @@ func TestSearchImageCmd(t *testing.T) {
 			buff := bytes.NewBufferString("")
 			configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 			defer os.Remove(configPath)
-			imageCmd := NewImageCommand(new(mockService), configPath)
+			imageCmd := NewImageCommand(new(mockService))
 			imageCmd.SetOut(buff)
 			imageCmd.SetErr(ioutil.Discard)
 			imageCmd.SetArgs(args)
@@ -189,7 +190,7 @@ func TestOutputFormat(t *testing.T) {
 		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 		defer os.Remove(configPath)
 
-		cmd := NewImageCommand(new(mockService), configPath)
+		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -207,7 +208,7 @@ func TestOutputFormat(t *testing.T) {
 		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 		defer os.Remove(configPath)
 
-		cmd := NewImageCommand(new(mockService), configPath)
+		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -226,7 +227,7 @@ func TestOutputFormat(t *testing.T) {
 		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 		defer os.Remove(configPath)
 
-		cmd := NewImageCommand(new(mockService), configPath)
+		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(ioutil.Discard)
@@ -244,7 +245,7 @@ func TestOutputFormat(t *testing.T) {
 			configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 			defer os.Remove(configPath)
 
-			cmd := NewImageCommand(new(mockService), configPath)
+			cmd := NewImageCommand(new(mockService))
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(ioutil.Discard)
@@ -264,7 +265,7 @@ func TestOutputFormat(t *testing.T) {
 		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 		defer os.Remove(configPath)
 
-		cmd := NewImageCommand(new(mockService), configPath)
+		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -315,7 +316,7 @@ func TestServerResponse(t *testing.T) {
 			args := []string{"imagetest"}
 			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 			defer os.Remove(configPath)
-			cmd := NewImageCommand(new(searchService), configPath)
+			cmd := NewImageCommand(new(searchService))
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -334,7 +335,7 @@ func TestServerResponse(t *testing.T) {
 			args := []string{"imagetest", "--name", "repo7"}
 			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 			defer os.Remove(configPath)
-			cmd := NewImageCommand(new(searchService), configPath)
+			cmd := NewImageCommand(new(searchService))
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -352,7 +353,7 @@ func TestServerResponse(t *testing.T) {
 				args := []string{"imagetest", "-n", "repo7"}
 				configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 				defer os.Remove(configPath)
-				cmd := NewImageCommand(new(searchService), configPath)
+				cmd := NewImageCommand(new(searchService))
 				buff := bytes.NewBufferString("")
 				cmd.SetOut(buff)
 				cmd.SetErr(buff)
@@ -372,7 +373,7 @@ func TestServerResponse(t *testing.T) {
 			args := []string{"imagetest", "--name", "repo777"}
 			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 			defer os.Remove(configPath)
-			cmd := NewImageCommand(new(searchService), configPath)
+			cmd := NewImageCommand(new(searchService))
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -483,17 +484,18 @@ func (service mockService) getImageByName(ctx context.Context, serverURL, userna
 }
 
 func makeConfigFile(content string) string {
-	f, err := ioutil.TempFile("", "config-*.properties")
+	os.Setenv("HOME", os.TempDir())
+	home, err := os.UserHomeDir()
+
 	if err != nil {
 		panic(err)
 	}
 
-	defer f.Close()
+	configPath := path.Join(home + "/.zot")
 
-	text := []byte(content)
-	if err := ioutil.WriteFile(f.Name(), text, 0600); err != nil {
+	if err := ioutil.WriteFile(configPath, []byte(content), 0600); err != nil {
 		panic(err)
 	}
 
-	return f.Name()
+	return configPath
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -19,7 +19,7 @@ func metadataConfig(md *mapstructure.Metadata) viper.DecoderConfigOption {
 	}
 }
 
-func NewRootCmd(configPath string) *cobra.Command {
+func NewRootCmd() *cobra.Command {
 	showVersion := false
 	config := api.NewConfig()
 
@@ -97,8 +97,8 @@ func NewRootCmd(configPath string) *cobra.Command {
 	rootCmd.AddCommand(serveCmd)
 	rootCmd.AddCommand(gcCmd)
 
-	rootCmd.AddCommand(NewConfigCommand(configPath))
-	rootCmd.AddCommand(NewImageCommand(NewImageSearchService(), configPath))
+	rootCmd.AddCommand(NewConfigCommand())
+	rootCmd.AddCommand(NewImageCommand(NewImageSearchService()))
 
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "show the version and exit")
 

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -17,13 +17,13 @@ func TestUsage(t *testing.T) {
 
 	Convey("Test usage", t, func(c C) {
 		os.Args = []string{"cli_test", "help"}
-		err := cli.NewRootCmd(os.TempDir()).Execute()
+		err := cli.NewRootCmd().Execute()
 		So(err, ShouldBeNil)
 	})
 
 	Convey("Test version", t, func(c C) {
 		os.Args = []string{"cli_test", "--version"}
-		err := cli.NewRootCmd(os.TempDir()).Execute()
+		err := cli.NewRootCmd().Execute()
 		So(err, ShouldBeNil)
 	})
 }
@@ -35,19 +35,19 @@ func TestServe(t *testing.T) {
 
 	Convey("Test serve help", t, func(c C) {
 		os.Args = []string{"cli_test", "serve", "-h"}
-		err := cli.NewRootCmd(os.TempDir()).Execute()
+		err := cli.NewRootCmd().Execute()
 		So(err, ShouldBeNil)
 	})
 
 	Convey("Test serve config", t, func(c C) {
 		Convey("unknown config", func(c C) {
 			os.Args = []string{"cli_test", "serve", path.Join(os.TempDir(), "/x")}
-			So(func() { _ = cli.NewRootCmd(os.TempDir()).Execute() }, ShouldPanic)
+			So(func() { _ = cli.NewRootCmd().Execute() }, ShouldPanic)
 		})
 
 		Convey("non-existent config", func(c C) {
 			os.Args = []string{"cli_test", "serve", path.Join(os.TempDir(), "/x.yaml")}
-			So(func() { _ = cli.NewRootCmd(os.TempDir()).Execute() }, ShouldPanic)
+			So(func() { _ = cli.NewRootCmd().Execute() }, ShouldPanic)
 		})
 
 		Convey("bad config", func(c C) {
@@ -60,7 +60,7 @@ func TestServe(t *testing.T) {
 			err = tmpfile.Close()
 			So(err, ShouldBeNil)
 			os.Args = []string{"cli_test", "serve", tmpfile.Name()}
-			So(func() { _ = cli.NewRootCmd(os.TempDir()).Execute() }, ShouldPanic)
+			So(func() { _ = cli.NewRootCmd().Execute() }, ShouldPanic)
 		})
 	})
 }
@@ -72,7 +72,7 @@ func TestGC(t *testing.T) {
 
 	Convey("Test gc", t, func(c C) {
 		os.Args = []string{"cli_test", "garbage-collect", "-h"}
-		err := cli.NewRootCmd(os.TempDir()).Execute()
+		err := cli.NewRootCmd().Execute()
 		So(err, ShouldBeNil)
 	})
 }

--- a/pkg/cli/searcher.go
+++ b/pkg/cli/searcher.go
@@ -120,9 +120,9 @@ func collectImages(outputFormat *string, stdWriter io.Writer, wg *sync.WaitGroup
 				return
 			}
 
-			if !foundResult && (*outputFormat == "text" || *outputFormat == "") {
-				spinner.stopSpinner()
+			spinner.stopSpinner()
 
+			if !foundResult && (*outputFormat == "text" || *outputFormat == "") {
 				var builder strings.Builder
 
 				printImageTableHeader(&builder)


### PR DESCRIPTION
earlier, some of the client exclusive code was being run on zot server
instance too. That caused an error when server doesn't have env variables required by client.

This PR moves that code out of the way of server