### PR TITLE
cli: add option to ignore TLS verification

### DIFF
--- a/pkg/cli/config_cmd.go
+++ b/pkg/cli/config_cmd.go
@@ -205,6 +205,7 @@ func addConfig(configPath, configName, url string) error {
 	configMap := make(map[string]interface{})
 	configMap["url"] = url
 	configMap[nameKey] = configName
+	addDefaultConfigs(configMap)
 	configs = append(configs, configMap)
 
 	err = saveConfigMapToFile(configPath, configs)
@@ -213,6 +214,16 @@ func addConfig(configPath, configName, url string) error {
 	}
 
 	return nil
+}
+
+func addDefaultConfigs(config map[string]interface{}) {
+	if _, ok := config[showspinnerConfig]; !ok {
+		config[showspinnerConfig] = true
+	}
+
+	if _, ok := config[verifyTLSConfig]; !ok {
+		config[verifyTLSConfig] = true
+	}
 }
 
 func getConfigValue(configPath, configName, key string) (string, error) {
@@ -227,6 +238,7 @@ func getConfigValue(configPath, configName, key string) (string, error) {
 
 	for _, val := range configs {
 		configMap := val.(map[string]interface{})
+		addDefaultConfigs(configMap)
 
 		name := configMap[nameKey]
 		if name == configName {
@@ -257,6 +269,7 @@ func resetConfigValue(configPath, configName, key string) error {
 
 	for _, val := range configs {
 		configMap := val.(map[string]interface{})
+		addDefaultConfigs(configMap)
 
 		name := configMap[nameKey]
 		if name == configName {
@@ -290,6 +303,7 @@ func setConfigValue(configPath, configName, key, value string) error {
 
 	for _, val := range configs {
 		configMap := val.(map[string]interface{})
+		addDefaultConfigs(configMap)
 
 		name := configMap[nameKey]
 		if name == configName {
@@ -326,6 +340,7 @@ func getAllConfig(configPath, configName string) (string, error) {
 
 	for _, value := range configs {
 		configMap := value.(map[string]interface{})
+		addDefaultConfigs(configMap)
 
 		name := configMap[nameKey]
 		if name == configName {
@@ -353,7 +368,8 @@ const (
 	supportedOptions = `
 Useful variables:
   url		zot server URL
-  showspinner	show spinner while loading data [true/false]`
+  showspinner	show spinner while loading data [true/false]
+  verify-tls	verify TLS Certificate verification of the server [default: true]`
 
 	nameKey = "_name"
 
@@ -361,6 +377,9 @@ Useful variables:
 	oneArg    = 1
 	twoArgs   = 2
 	threeArgs = 3
+
+	showspinnerConfig = "showspinner"
+	verifyTLSConfig   = "verify-tls"
 )
 
 var (

--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -439,8 +439,8 @@ func uploadManifest(url string) {
 
 type mockService struct{}
 
-func (service mockService) getAllImages(ctx context.Context, serverURL, username, password,
-	outputFormat string, channel chan imageListResult, wg *sync.WaitGroup) {
+func (service mockService) getAllImages(ctx context.Context, config searchConfig, username, password string,
+	channel chan imageListResult, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	image := &imageStruct{}
@@ -453,7 +453,7 @@ func (service mockService) getAllImages(ctx context.Context, serverURL, username
 		},
 	}
 
-	str, err := image.string(outputFormat)
+	str, err := image.string(*config.outputFormat)
 	if err != nil {
 		channel <- imageListResult{"", err}
 		return
@@ -461,8 +461,8 @@ func (service mockService) getAllImages(ctx context.Context, serverURL, username
 	channel <- imageListResult{str, nil}
 }
 
-func (service mockService) getImageByName(ctx context.Context, serverURL, username, password,
-	imageName, outputFormat string, channel chan imageListResult, wg *sync.WaitGroup) {
+func (service mockService) getImageByName(ctx context.Context, config searchConfig,
+	username, password, imageName string, channel chan imageListResult, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	image := &imageStruct{}
@@ -475,7 +475,7 @@ func (service mockService) getImageByName(ctx context.Context, serverURL, userna
 		},
 	}
 
-	str, err := image.string(outputFormat)
+	str, err := image.string(*config.outputFormat)
 	if err != nil {
 		channel <- imageListResult{"", err}
 		return


### PR DESCRIPTION
adds a property in config : "verify-tls". It allows user to make unsecured HTTPS connections by skipping TLS certificate verification

```console
$ zot config add local https://localhost:8080         
$ zot config local -l                       
url = http://localhost:8080
showspinner = true
verify-tls = true
$ zot config local verify-tls false
$ zot config local -l                       
url = https://localhost:8080
showspinner = true
verify-tls = false
```