### PR TITLE
Dedupe fix

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -890,7 +890,7 @@ retry:
 		if err != nil {
 			is.log.Error().Err(err).Str("blobPath", dstRecord).Msg("dedupe: unable to stat")
 			// the actual blob on disk may have been removed by GC, so sync the cache
-			if err := is.cache.DeleteBlob(dstDigest.String(), dst); err != nil {
+			if err := is.cache.DeleteBlob(dstDigest.String(), dstRecord); err != nil {
 				// nolint:lll
 				is.log.Error().Err(err).Str("dstDigest", dstDigest.String()).Str("dst", dst).Msg("dedupe: unable to delete blob record")
 


### PR DESCRIPTION
**Steps to reproduce this issue (locally):-** 

1. Upload an image on zot server.
2. Manually delete any image blobs. 
3. Try to upload same image with different name.

**Fix:-** 
Using "destRecord" as a path in DeleteBlob function instead of "dst". 

dstRecord :- blob path stored in cache.
dst :- blob path that is trying to be uploaded. 

Currently, if the actual blob on disk may have been removed by GC/delete, during syncing the cache dst is being passed to DeleteBlob function and retry section is being continuously called because DeleteBlob function never deletes dst path (doesn't exist in db), dstRecord should be passed into DeleteBlob function because dstRecord is actual blob path stored in db.

If dst and dstRecord path value is same then this issue will not be produced and DeleteBlob method will delete the blob info from cache but if both are different then DeleteBlob method will try to delete dst path which is not in cache. 

Note:- boltdb delete method return nil even when value doesn't exist (https://godoc.org/github.com/boltdb/bolt#Bucket.Delete)

