### PR TITLE
Enable wait option during travis ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,8 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -N https://github.com/bazelbuild/bazel/releases/download/3.0.0/bazel-3.0.0-installer-linux-x86_64.sh && chmod +x bazel-3.0.0-installer-linux-x86_64.sh && ./bazel-3.0.0-installer-linux-x86_64.sh --user; go get -u github.com/swaggo/swag/cmd/swag; go mod download; sudo apt-get update; sudo apt-get install rpm; sudo apt install snapd; sudo snap install skopeo --edge --devmode; fi
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make && make -f Makefile.bazel build; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make && travis_wait make -f Makefile.bazel build; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-
-script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make && make -f Makefile.bazel build; fi
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
During running of bazel build we have selected no progress option during bazel build and it does not print any console outputs, travis expects some console outputs during build and if nothing printed to console for some time it exits the whole process. 

Adding travis_wait option during running of bazel build command, this will print a message on console every minute for 20 minutes.