### PR TITLE
Fixes issue #132

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -35,6 +35,5 @@ var (
 	ErrNoURLProvided           = errors.New("cli: no URL provided in argument or via config. see 'zot config -h'")
 	ErrIllegalConfigKey        = errors.New("cli: given config key is not allowed")
 	ErrScanNotSupported        = errors.New("search: scanning of image media type not supported")
-	ErrFixedTagNotFound        = errors.New("search: no fixed tag found")
 	ErrCLITimeout              = errors.New("cli: Query timed out while waiting for results")
 )

--- a/pkg/cli/cve_cmd_test.go
+++ b/pkg/cli/cve_cmd_test.go
@@ -427,6 +427,23 @@ func TestServerCVEResponse(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(str, ShouldEqual, "")
 		})
+
+		Convey("invalid image", func() {
+			args := []string{"cvetest", "--cve-id", "CVE-2019-20807", "--image", "zot-cv-test", "--fixed"}
+			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, url))
+			defer os.Remove(configPath)
+			cveCmd := NewCveCommand(new(searchService))
+			buff := bytes.NewBufferString("")
+			cveCmd.SetOut(buff)
+			cveCmd.SetErr(ioutil.Discard)
+			cveCmd.SetArgs(args)
+			err := cveCmd.Execute()
+			space := regexp.MustCompile(`\s+`)
+			str := space.ReplaceAllString(buff.String(), " ")
+			str = strings.TrimSpace(str)
+			So(err, ShouldNotBeNil)
+			So(strings.TrimSpace(str), ShouldNotContainSubstring, "IMAGE NAME TAG DIGEST SIZE")
+		})
 	})
 
 	Convey("Test CVE by name and CVE ID", t, func() {

--- a/pkg/cli/service.go
+++ b/pkg/cli/service.go
@@ -394,12 +394,6 @@ func (service searchService) getFixedTagsForCVE(ctx context.Context, config sear
 		var errBuilder strings.Builder
 
 		for _, err := range result.Errors {
-			if err.Message == zotErrors.ErrFixedTagNotFound.Error() {
-				// this if block and goto should be removed when the server API is fixed.
-				// currently, the API returns an error if the data is empty and we are ignoring that error here
-				goto Outside
-			}
-
 			fmt.Fprintln(&errBuilder, err.Message)
 		}
 
@@ -411,7 +405,6 @@ func (service searchService) getFixedTagsForCVE(ctx context.Context, config sear
 		return
 	}
 
-Outside:
 	var localWg sync.WaitGroup
 
 	p := newSmoothRateLimiter(ctx, &localWg, c)

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -36,6 +36,23 @@ type CveResult struct {
 	ImgList ImgList `json:"data"`
 }
 
+type ImgWithFixedCVE struct {
+	ImgResults ImgResults `json:"data"`
+}
+
+type ImgResults struct {
+	ImgResultForFixedCVE ImgResultForFixedCVE `json:"ImgResultForFixedCVE"`
+}
+
+type ImgResultForFixedCVE struct {
+	Tags []TagInfo `json:"Tags"`
+}
+
+type TagInfo struct {
+	Name      string
+	Timestamp time.Time
+}
+
 type ImgList struct {
 	CVEResultForImage CVEResultForImage `json:"CVEListForImage"`
 }
@@ -363,6 +380,15 @@ func TestCVESearch(t *testing.T) {
 		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(BaseURL1 + "/query?query={ImageListForCVE(id:\"" + id + "\"){Name%20Tags}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
+
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(BaseURL1 + "/query?query={ImageListWithCVEFixed(id:\"" + id + "\",image:\"zot-test\"){Tags{Name%20Timestamp}}}")
+		So(resp, ShouldNotBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+
+		var imgFixedCVEResult ImgWithFixedCVE
+		err = json.Unmarshal(resp.Body(), &imgFixedCVEResult)
+		So(err, ShouldBeNil)
+		So(len(imgFixedCVEResult.ImgResults.ImgResultForFixedCVE.Tags), ShouldEqual, 0)
 
 		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(BaseURL1 + "/query?query={ImageListWithCVEFixed(id:\"" + id + "\",image:\"zot-test\"){Tags{Name%20Timestamp}}}")
 		So(resp, ShouldNotBeNil)

--- a/pkg/extensions/search/resolver.go
+++ b/pkg/extensions/search/resolver.go
@@ -297,7 +297,5 @@ func (r *queryResolver) ImageListWithCVEFixed(ctx context.Context, id string, im
 
 	r.cveInfo.Log.Info().Msg("Input image does not contain any tag that does not have given cve")
 
-	imgResultForFixedCVE = &ImgResultForFixedCve{}
-
-	return imgResultForFixedCVE, errors.ErrFixedTagNotFound
+	return imgResultForFixedCVE, nil
 }


### PR DESCRIPTION
If image does not have any fixed tags, empty list with no error should be returned