### PR TITLE
fix the binary-stacker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+os: linux
 
 go:
   - 1.14.x
@@ -19,10 +20,21 @@ cache:
     - $HOME/.cache/bazel
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -N https://github.com/bazelbuild/bazel/releases/download/3.0.0/bazel-3.0.0-installer-linux-x86_64.sh && chmod +x bazel-3.0.0-installer-linux-x86_64.sh && ./bazel-3.0.0-installer-linux-x86_64.sh --user; go get -u github.com/swaggo/swag/cmd/swag; go mod download; sudo apt-get update; sudo apt-get install rpm uidmap; sudo apt install snapd; sudo snap install skopeo --edge --devmode; fi
+  - wget -N https://github.com/bazelbuild/bazel/releases/download/3.0.0/bazel-3.0.0-installer-linux-x86_64.sh
+  - chmod +x bazel-3.0.0-installer-linux-x86_64.sh
+  - ./bazel-3.0.0-installer-linux-x86_64.sh --user
+  - go get -u github.com/swaggo/swag/cmd/swag
+  - go mod download
+  - sudo apt-get update
+  - sudo apt-get install rpm uidmap
+  - which newgidmap
+  - echo $PATH
+  - sudo apt install snapd
+  - sudo snap install skopeo --edge --devmode
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make && travis_wait make -f Makefile.bazel build; fi
+  - make
+  - travis_wait make -f Makefile.bazel build
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ debug: doc
 
 .PHONY: test
 test:
-	$(shell mkdir -p test/data;  cd test/data; ../scripts/gen_certs.sh; cd ${TOP_LEVEL}; sudo skopeo --insecure-policy copy -q docker://centos:latest oci:${TOP_LEVEL}/test/data/zot-test:0.0.1;sudo skopeo --insecure-policy copy -q docker://centos:8 oci:${TOP_LEVEL}/test/data/zot-cve-test:0.0.1)
+	mkdir -p test/data
+	./test/scripts/gen_certs.sh ./test/data
+	skopeo --insecure-policy copy docker://centos:latest oci:./test/data/zot-test:0.0.1
+	skopeo --insecure-policy copy docker://centos:8 oci:./test/data/zot-cve-test:0.0.1
 	go test -v -race -cover -coverpkg ./... -coverprofile=coverage.txt -covermode=atomic ./...
 
 .PHONY: covhtml
@@ -54,7 +57,7 @@ binary-container:
 
 .PHONY: binary-stacker
 binary-stacker:
-	stacker --roots-dir ${TMPDIR} build --substitute PWD=$$PWD
+	stacker build --substitute PWD=$$PWD
 
 .PHONY: image
 image:

--- a/stacker.yaml
+++ b/stacker.yaml
@@ -1,10 +1,20 @@
+skopeo:
+  from:
+    type: docker
+    url: docker://twistedvines/skopeo
 build:
   from:
     type: docker
     url: docker://golang:1.14.4
   binds:
-    - ${{PWD}} -> /go/src/github.com/anuvu/zot
+    - ${{PWD}} -> /zotcopy
+  import:
+    - stacker://skopeo/usr/local/bin/skopeo
   run: |
+    cp /stacker/skopeo /usr/bin/
+    mkdir -p /go/src/github.com/anuvu
+    cd /go/src/github.com/anuvu
+    git clone /zotcopy zot
     export GO111MODULE=on 
     export GOPATH='/go'
     export HOME='/root'
@@ -13,7 +23,7 @@ build:
     cd /go/src/github.com/anuvu/zot
     go get -u -v -d ./...
     curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.26.0
-    make
+    make binary
   build_only: true
 
 zot:

--- a/stacker.yaml
+++ b/stacker.yaml
@@ -11,6 +11,7 @@ build:
   import:
     - stacker://skopeo/usr/local/bin/skopeo
   run: |
+    apt-get -y install uidmap
     cp /stacker/skopeo /usr/bin/
     mkdir -p /go/src/github.com/anuvu
     cd /go/src/github.com/anuvu

--- a/test/scripts/gen_certs.sh
+++ b/test/scripts/gen_certs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xe
 
+[ -n "$1" ] && cd $1
+
 openssl req \
     -newkey rsa:2048 \
     -nodes \


### PR DESCRIPTION
1. import skopeo from twistedfines/skopeo image
2. don't use sudo and -q
  1. centos container doesn't have sudo
  2. 'sudo' from an unprivileged 'make' is evil
  3. the skopeo we're fetching doesn't know -q
3. don't use /tmp

Signed-off-by: Serge Hallyn <shallyn@cisco.com>