### PR TITLE
routes: refactor locks to handle large file uploads

### DIFF
--- a/pkg/api/BUILD.bazel
+++ b/pkg/api/BUILD.bazel
@@ -36,7 +36,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    timeout = "moderate",
+    timeout = "long",
     srcs = ["controller_test.go"],
     data = [
         "//:exported_testdata",
@@ -49,7 +49,9 @@ go_test(
         "@com_github_mitchellh_mapstructure//:go_default_library",
         "@com_github_nmcclain_ldap//:go_default_library",
         "@com_github_opencontainers_go_digest//:go_default_library",
+        "@com_github_opencontainers_image_spec//specs-go/v1:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@in_gopkg_resty_v1//:go_default_library",
         "@org_golang_x_crypto//bcrypt:go_default_library",
     ],

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -6,12 +6,14 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path"
 	"regexp"
 	"strings"
 	"testing"
@@ -23,9 +25,12 @@ import (
 	"github.com/anuvu/zot/pkg/api"
 	"github.com/chartmuseum/auth"
 	"github.com/mitchellh/mapstructure"
-	vldap "github.com/nmcclain/ldap"
 	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	vldap "github.com/nmcclain/ldap"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/resty.v1"
 )
 
@@ -101,6 +106,7 @@ func getCredString(username, password string) string {
 
 	return usernameAndHash
 }
+
 func TestNew(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		config := api.NewConfig()
@@ -1514,4 +1520,368 @@ func TestHTTPReadOnly(t *testing.T) {
 			}()
 		}
 	})
+}
+
+func TestParallelRequests(t *testing.T) {
+	testCases := []struct {
+		srcImageName  string
+		srcImageTag   string
+		destImageName string
+		destImageTag  string
+		testCaseName  string
+	}{
+		{
+			srcImageName:  "zot-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-1-test",
+			destImageTag:  "0.0.1",
+			testCaseName:  "Request-1",
+		},
+		{
+			srcImageName:  "zot-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-2-test",
+			testCaseName:  "Request-2",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-3-test",
+			testCaseName:  "Request-3",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-4-test",
+			testCaseName:  "Request-4",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-5-test",
+			testCaseName:  "Request-5",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-1-test",
+			testCaseName:  "Request-6",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-2-test",
+			testCaseName:  "Request-7",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-3-test",
+			testCaseName:  "Request-8",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-4-test",
+			testCaseName:  "Request-9",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-5-test",
+			testCaseName:  "Request-10",
+		},
+		{
+			srcImageName:  "zot-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-1-test",
+			destImageTag:  "0.0.1",
+			testCaseName:  "Request-11",
+		},
+		{
+			srcImageName:  "zot-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-2-test",
+			testCaseName:  "Request-12",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-3-test",
+			testCaseName:  "Request-13",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-4-test",
+			testCaseName:  "Request-14",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-5-test",
+			testCaseName:  "Request-15",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-1-test",
+			testCaseName:  "Request-16",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-2-test",
+			testCaseName:  "Request-17",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-3-test",
+			testCaseName:  "Request-18",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-4-test",
+			testCaseName:  "Request-19",
+		},
+		{
+			srcImageName:  "zot-cve-test",
+			srcImageTag:   "0.0.1",
+			destImageName: "zot-5-test",
+			testCaseName:  "Request-20",
+		},
+	}
+
+	config := api.NewConfig()
+	config.HTTP.Port = SecurePort1
+	htpasswdPath := makeHtpasswdFileFromString(getCredString(username, passphrase))
+
+	defer os.Remove(htpasswdPath)
+
+	config.HTTP.Auth = &api.AuthConfig{
+		HTPasswd: api.AuthHTPasswd{
+			Path: htpasswdPath,
+		},
+	}
+
+	c := api.NewController(config)
+
+	dir, err := ioutil.TempDir("", "oci-repo-test")
+	if err != nil {
+		panic(err)
+	}
+
+	err = copyFiles("../../test/data", dir)
+	if err != nil {
+		panic(err)
+	}
+	//defer os.RemoveAll(dir)
+	c.Config.Storage.RootDirectory = dir
+
+	go func() {
+		// this blocks
+		if err := c.Run(); err != nil {
+			return
+		}
+	}()
+
+	// wait till ready
+	for {
+		_, err := resty.R().Get(BaseURL1)
+		if err == nil {
+			break
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// without creds, should get access error
+	for _, testcase := range testCases {
+		testcase := testcase
+		t.Run(testcase.testCaseName, func(t *testing.T) {
+			t.Parallel()
+			blobList := getAllBlobs(path.Join(c.Config.Storage.RootDirectory, testcase.srcImageName))
+
+			client := resty.New()
+
+			for _, blob := range blobList {
+				// Get request of blob
+				_, err := client.R().SetBasicAuth(username, passphrase).
+					Get(BaseURL1 + "/v2/" + testcase.destImageName + "/manifests/" + blob)
+				assert.Equal(t, err, nil, "Error should be nil")
+				// Head request of blob
+				_, err = client.R().SetBasicAuth(username, passphrase).
+					Get(BaseURL1 + "/v2/" + testcase.destImageName + "/manifests/" + blob)
+				assert.Equal(t, err, nil, "Error should be nil")
+
+				blobPath := path.Join(c.Config.Storage.RootDirectory, testcase.srcImageName, "blobs/sha256", blob)
+
+				buf, err := ioutil.ReadFile(blobPath)
+				if err != nil {
+					panic(err)
+				}
+
+				// Post request of blob
+				postResponse, err := client.R().
+					SetHeader("Content-type", "application/octet-stream").
+					SetBasicAuth(username, passphrase).
+					SetBody(buf).Post(BaseURL1 + "/v2/" + testcase.destImageName + "/blobs/uploads/")
+
+				assert.Equal(t, err, nil, "Error should be nil")
+				assert.NotEqual(t, postResponse.StatusCode(), 500, "response status code should not return 500")
+
+				// Post request with query parameter
+
+				postResponse, err = client.R().
+					SetHeader("Content-type", "application/octet-stream").
+					SetBasicAuth(username, passphrase).
+					SetBody(buf).SetQueryParam("digest", "sha256:"+blob).
+					Post(BaseURL1 + "/v2/" + testcase.destImageName + "/blobs/uploads/")
+
+				assert.Equal(t, err, nil, "Error should be nil")
+				assert.NotEqual(t, postResponse.StatusCode(), 500, "response status code should not return 500")
+
+				/*var sessionID string
+				sessionIDList := postResponse.Header().Values("Blob-Upload-UUID")
+
+				if len(sessionIDList) == 0 {
+					location := postResponse.Header().Values("Location")
+					firstLocation := location[0]
+					splitLocation := strings.Split(firstLocation, "/")
+					sessionID = splitLocation[len(splitLocation)-1]
+				} else {
+					sessionID = sessionIDList[0]
+				}
+				// Patch request of blob
+				_, err = client.R().SetBody(buf).SetHeader("Content-type", "application/octet-stream").
+				SetBasicAuth(username, passphrase).
+				Patch(BaseURL1 + "/v2/" + testcase.destImageName + "/blobs/uploads/" + sessionID)
+				if err != nil {
+					panic(err)
+				}
+
+				// Put request of blob
+				_, err = client.R().SetBody(buf).SetHeader("Content-type", "application/octet-stream").
+				SetBasicAuth(username, passphrase).
+				SetQueryParam("digest", "sha256:"+blob).
+				Put(BaseURL1 + "/v2/" + testcase.destImageName + "/blobs/uploads/" + sessionID)
+				if err != nil {
+					panic(err)
+				}*/
+
+				headResponse, err := client.R().
+					SetBasicAuth(username, passphrase).
+					Head(BaseURL1 + "/v2/" + testcase.destImageName + "/blobs/sha256:" + blob)
+
+				assert.Equal(t, err, nil, "Should not be nil")
+				assert.Equal(t, headResponse.StatusCode(), 200, "response should return success code")
+			}
+		})
+	}
+}
+
+func getAllBlobs(imagePath string) []string {
+	blobList := make([]string, 0)
+
+	if !dirExists(imagePath) {
+		return []string{}
+	}
+
+	buf, err := ioutil.ReadFile(path.Join(imagePath, "index.json"))
+
+	if err != nil {
+		panic(err)
+	}
+
+	var index ispec.Index
+	if err := json.Unmarshal(buf, &index); err != nil {
+		panic(err)
+	}
+
+	var digest godigest.Digest
+
+	for _, m := range index.Manifests {
+		digest = m.Digest
+		blobList = append(blobList, digest.Encoded())
+		p := path.Join(imagePath, "blobs", digest.Algorithm().String(), digest.Encoded())
+
+		buf, err = ioutil.ReadFile(p)
+
+		if err != nil {
+			panic(err)
+		}
+
+		var manifest ispec.Manifest
+		if err := json.Unmarshal(buf, &manifest); err != nil {
+			panic(err)
+		}
+
+		blobList = append(blobList, manifest.Config.Digest.Encoded())
+
+		for _, layer := range manifest.Layers {
+			blobList = append(blobList, layer.Digest.Encoded())
+		}
+	}
+
+	return blobList
+}
+
+func dirExists(d string) bool {
+	fi, err := os.Stat(d)
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+
+	if !fi.IsDir() {
+		return false
+	}
+
+	return true
+}
+
+func copyFiles(sourceDir string, destDir string) error {
+	sourceMeta, err := os.Stat(sourceDir)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(destDir, sourceMeta.Mode()); err != nil {
+		return err
+	}
+
+	files, err := ioutil.ReadDir(sourceDir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		sourceFilePath := path.Join(sourceDir, file.Name())
+		destFilePath := path.Join(destDir, file.Name())
+
+		if file.IsDir() {
+			if err = copyFiles(sourceFilePath, destFilePath); err != nil {
+				return err
+			}
+		} else {
+			sourceFile, err := os.Open(sourceFilePath)
+			if err != nil {
+				return err
+			}
+			defer sourceFile.Close()
+
+			destFile, err := os.Create(destFilePath)
+			if err != nil {
+				return err
+			}
+			defer destFile.Close()
+
+			if _, err = io.Copy(destFile, sourceFile); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/cli/cve_cmd_test.go
+++ b/pkg/cli/cve_cmd_test.go
@@ -326,7 +326,7 @@ func TestServerCVEResponse(t *testing.T) {
 
 		time.Sleep(100 * time.Millisecond)
 	}
-	time.Sleep(25 * time.Second)
+	time.Sleep(35 * time.Second)
 
 	defer func(controller *api.Controller) {
 		ctx := context.Background()

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -503,7 +503,7 @@ func TestCVESearch(t *testing.T) {
 		}
 
 		// Wait for trivy db to download
-		time.Sleep(30 * time.Second)
+		time.Sleep(35 * time.Second)
 
 		defer func() {
 			ctx := context.Background()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -111,6 +111,9 @@ func (is *ImageStore) Unlock() {
 func (is *ImageStore) InitRepo(name string) error {
 	repoDir := path.Join(is.rootDir, name)
 
+	is.Lock()
+	defer is.Unlock()
+
 	if fi, err := os.Stat(repoDir); err == nil && fi.IsDir() {
 		return nil
 	}
@@ -217,6 +220,9 @@ func (is *ImageStore) ValidateRepo(name string) (bool, error) {
 func (is *ImageStore) GetRepositories() ([]string, error) {
 	dir := is.rootDir
 
+	is.RLock()
+	defer is.RUnlock()
+
 	_, err := ioutil.ReadDir(dir)
 	if err != nil {
 		is.log.Error().Err(err).Msg("failure walking storage root-dir")
@@ -258,6 +264,9 @@ func (is *ImageStore) GetImageTags(repo string) ([]string, error) {
 		return nil, errors.ErrRepoNotFound
 	}
 
+	is.RLock()
+	defer is.RUnlock()
+
 	buf, err := ioutil.ReadFile(path.Join(dir, "index.json"))
 	if err != nil {
 		is.log.Error().Err(err).Str("dir", dir).Msg("failed to read index.json")
@@ -288,6 +297,9 @@ func (is *ImageStore) GetImageManifest(repo string, reference string) ([]byte, s
 	if !dirExists(dir) {
 		return nil, "", "", errors.ErrRepoNotFound
 	}
+
+	is.RLock()
+	defer is.RUnlock()
 
 	buf, err := ioutil.ReadFile(path.Join(dir, "index.json"))
 
@@ -414,6 +426,9 @@ func (is *ImageStore) PutImageManifest(repo string, reference string, mediaType 
 		refIsDigest = true
 	}
 
+	is.Lock()
+	defer is.Unlock()
+
 	dir := path.Join(is.rootDir, repo)
 	buf, err := ioutil.ReadFile(path.Join(dir, "index.json"))
 
@@ -524,6 +539,9 @@ func (is *ImageStore) DeleteImageManifest(repo string, reference string) error {
 	if !dirExists(dir) {
 		return errors.ErrRepoNotFound
 	}
+
+	is.Lock()
+	defer is.Unlock()
 
 	// as per spec "reference" can only be a digest and not a tag
 	digest, err := godigest.Parse(reference)
@@ -770,6 +788,10 @@ func (is *ImageStore) FinishBlobUpload(repo string, uuid string, body io.Reader,
 	}
 
 	dir := path.Join(is.rootDir, repo, "blobs", dstDigest.Algorithm().String())
+
+	is.Lock()
+	defer is.Unlock()
+
 	ensureDir(dir, is.log)
 	dst := is.BlobPath(repo, dstDigest)
 
@@ -835,6 +857,10 @@ func (is *ImageStore) FullBlobUpload(repo string, body io.Reader, digest string)
 	}
 
 	dir := path.Join(is.rootDir, repo, "blobs", dstDigest.Algorithm().String())
+
+	is.Lock()
+	defer is.Unlock()
+
 	ensureDir(dir, is.log)
 	dst := is.BlobPath(repo, dstDigest)
 
@@ -948,6 +974,9 @@ func (is *ImageStore) CheckBlob(repo string, digest string,
 
 	blobPath := is.BlobPath(repo, d)
 
+	is.RLock()
+	defer is.RUnlock()
+
 	blobInfo, err := os.Stat(blobPath)
 	if err != nil {
 		is.log.Error().Err(err).Str("blob", blobPath).Msg("failed to stat blob")
@@ -968,6 +997,9 @@ func (is *ImageStore) GetBlob(repo string, digest string, mediaType string) (io.
 	}
 
 	blobPath := is.BlobPath(repo, d)
+
+	is.RLock()
+	defer is.RUnlock()
 
 	blobInfo, err := os.Stat(blobPath)
 	if err != nil {
@@ -993,6 +1025,9 @@ func (is *ImageStore) DeleteBlob(repo string, digest string) error {
 	}
 
 	blobPath := is.BlobPath(repo, d)
+
+	is.Lock()
+	defer is.Unlock()
 
 	_, err = os.Stat(blobPath)
 	if err != nil {


### PR DESCRIPTION
The storage layer is protected with read-write locks.
However, we may be holding the locks over unnecessarily large critical
sections.

The typical workflow is that a blob is first uploaded via a per-client
private session-id meaning the blob is not publicly visible yet. When
the blob being uploaded is very large, the transfer takes a long time
while holding the lock.

Private session-id based uploads don't really need locks, and hold locks
only when blobs are published after the upload is complete.