### PR TITLE
Customizable binaries

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/anuvu/zot/errors"
-	cveinfo "github.com/anuvu/zot/pkg/extensions/search/cve"
+	"github.com/anuvu/zot/pkg/extensions"
 	"github.com/anuvu/zot/pkg/log"
 	"github.com/anuvu/zot/pkg/storage"
 	"github.com/gorilla/handlers"
@@ -62,17 +62,10 @@ func (c *Controller) Run() error {
 		}
 
 		go func() {
-			for {
-				c.Log.Info().Msg("Updating the CVE database")
-
-				err := cveinfo.UpdateCVEDb(c.Config.Storage.RootDirectory, c.Log)
-				if err != nil {
-					panic(err)
-				}
-
-				c.Log.Info().Str("Db update completed, next update scheduled after", c.Config.Extensions.Search.CVE.UpdateInterval.String()).Msg("") //nolint: lll
-
-				time.Sleep(c.Config.Extensions.Search.CVE.UpdateInterval)
+			err := extensions.DownloadTrivyDB(c.Config.Storage.RootDirectory, c.Log,
+				c.Config.Extensions.Search.CVE.UpdateInterval)
+			if err != nil {
+				panic(err)
 			}
 		}()
 	} else {

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -1,0 +1,45 @@
+// +build extended
+
+package extensions
+
+import (
+	"github.com/anuvu/zot/pkg/extensions/search"
+	"github.com/anuvu/zot/pkg/storage"
+
+	"time"
+
+	gqlHandler "github.com/99designs/gqlgen/graphql/handler"
+	cveinfo "github.com/anuvu/zot/pkg/extensions/search/cve"
+
+	"github.com/anuvu/zot/pkg/log"
+)
+
+// Extension Server for graphql...
+type ExtensionServer struct {
+	GraphqlServer *gqlHandler.Server
+}
+
+// DownloadTrivyDB ...
+func DownloadTrivyDB(dbDir string, log log.Logger, updateInterval time.Duration) error {
+	for {
+		log.Info().Msg("Updating the CVE database")
+
+		err := cveinfo.UpdateCVEDb(dbDir, log)
+		if err != nil {
+			return err
+		}
+
+		log.Info().Str("Db update completed, next update scheduled after", updateInterval.String()).Msg("")
+
+		time.Sleep(updateInterval)
+	}
+}
+
+// ExtensionHandler ...
+func ExtensionHandler(rootDir string, log log.Logger, imgStore *storage.ImageStore) *ExtensionServer {
+	extensionServer := &ExtensionServer{}
+	resConfig := search.GetResolverConfig(rootDir, log, imgStore)
+	extensionServer.GraphqlServer = gqlHandler.NewDefaultServer(search.NewExecutableSchema(resConfig))
+
+	return extensionServer
+}

--- a/pkg/extensions/extension_minimal.go
+++ b/pkg/extensions/extension_minimal.go
@@ -1,0 +1,26 @@
+// +build minimal
+
+package extensions
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/anuvu/zot/pkg/log"
+	"github.com/anuvu/zot/pkg/storage"
+)
+
+// ExtensionServer ...
+type ExtensionServer struct {
+	GraphqlServer http.Handler
+}
+
+// DownloadTrivyDB ...
+func DownloadTrivyDB(dbDir string, log log.Logger, updateInterval time.Duration) error {
+	return nil
+}
+
+// ExtensionHandler ...
+func ExtensionHandler(rootDir string, log log.Logger, imgStore *storage.ImageStore) *ExtensionServer {
+	return &ExtensionServer{}
+}


### PR DESCRIPTION
This PR will close this https://aci-github.cisco.com/atom/atomix/issues/1093. Idea is to create a "zot-minimal" build target which only does dist-spec serving. 

Added two build tags minimal and extended, minimal will create a binary that only serves dist-spec serving while extended will include CVE scan also. 

Added one build rule (minimal-binary) also in Makefile, this rule will generate a minimal-binary while existing binary rule will now generate full binary.  