### PR TITLE
routes: refactor locks to handle large file uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -N https://github.com/bazelbuild/bazel/releases/download/3.0.0/bazel-3.0.0-installer-linux-x86_64.sh && chmod +x bazel-3.0.0-installer-linux-x86_64.sh && ./bazel-3.0.0-installer-linux-x86_64.sh --user; go get -u github.com/swaggo/swag/cmd/swag; go mod download; sudo apt-get update; sudo apt-get install rpm; sudo apt install snapd; sudo snap install skopeo --edge --devmode; fi
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make && travis_wait make -f Makefile.bazel build; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis_wait make && travis_wait make -f Makefile.bazel build; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.6.1
+	github.com/stretchr/testify v1.6.1
 	github.com/swaggo/http-swagger v0.0.0-20190614090009-c2865af9083e
 	github.com/swaggo/swag v1.6.3
 	github.com/vektah/gqlparser/v2 v2.0.1

--- a/pkg/api/BUILD.bazel
+++ b/pkg/api/BUILD.bazel
@@ -36,7 +36,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    timeout = "moderate",
+    timeout = "long",
     srcs = ["controller_test.go"],
     data = [
         "//:exported_testdata",
@@ -49,7 +49,9 @@ go_test(
         "@com_github_mitchellh_mapstructure//:go_default_library",
         "@com_github_nmcclain_ldap//:go_default_library",
         "@com_github_opencontainers_go_digest//:go_default_library",
+        "@com_github_opencontainers_image_spec//specs-go/v1:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@in_gopkg_resty_v1//:go_default_library",
         "@org_golang_x_crypto//bcrypt:go_default_library",
     ],

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -1617,42 +1617,6 @@ func TestParallelRequests(t *testing.T) {
 			destImageName: "zot-4-test",
 			testCaseName:  "Request-14",
 		},
-		{
-			srcImageName:  "zot-cve-test",
-			srcImageTag:   "0.0.1",
-			destImageName: "zot-5-test",
-			testCaseName:  "Request-15",
-		},
-		{
-			srcImageName:  "zot-cve-test",
-			srcImageTag:   "0.0.1",
-			destImageName: "zot-1-test",
-			testCaseName:  "Request-16",
-		},
-		{
-			srcImageName:  "zot-cve-test",
-			srcImageTag:   "0.0.1",
-			destImageName: "zot-2-test",
-			testCaseName:  "Request-17",
-		},
-		{
-			srcImageName:  "zot-cve-test",
-			srcImageTag:   "0.0.1",
-			destImageName: "zot-3-test",
-			testCaseName:  "Request-18",
-		},
-		{
-			srcImageName:  "zot-cve-test",
-			srcImageTag:   "0.0.1",
-			destImageName: "zot-4-test",
-			testCaseName:  "Request-19",
-		},
-		{
-			srcImageName:  "zot-cve-test",
-			srcImageTag:   "0.0.1",
-			destImageName: "zot-5-test",
-			testCaseName:  "Request-20",
-		},
 	}
 
 	config := api.NewConfig()
@@ -1792,7 +1756,7 @@ func TestParallelRequests(t *testing.T) {
 
 					reader := bufio.NewReader(file)
 
-					b := make([]byte, 1024*1024)
+					b := make([]byte, 5*1024*1024)
 
 					if j%4 == 0 {
 						readContent := 0

--- a/pkg/cli/cve_cmd_test.go
+++ b/pkg/cli/cve_cmd_test.go
@@ -326,7 +326,7 @@ func TestServerCVEResponse(t *testing.T) {
 
 		time.Sleep(100 * time.Millisecond)
 	}
-	time.Sleep(25 * time.Second)
+	time.Sleep(35 * time.Second)
 
 	defer func(controller *api.Controller) {
 		ctx := context.Background()

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -501,7 +501,7 @@ func TestCVESearch(t *testing.T) {
 		}
 
 		// Wait for trivy db to download
-		time.Sleep(30 * time.Second)
+		time.Sleep(35 * time.Second)
 
 		defer func() {
 			ctx := context.Background()

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -365,12 +365,10 @@ func makeHtpasswdFile() string {
 }
 
 func TestDownloadDB(t *testing.T) {
-	Convey("Download DB", t, func() {
+	Convey("Download DB passing invalid dir", t, func() {
 		err := testSetup()
 		So(err, ShouldBeNil)
-		err = cveinfo.UpdateCVEDb(dbDir, cve.Log)
-		So(err, ShouldBeNil)
-
+		// Test Invalid dir download
 		err = cveinfo.UpdateCVEDb("./testdata1", cve.Log)
 		So(err, ShouldNotBeNil)
 	})
@@ -462,6 +460,8 @@ func TestImageTag(t *testing.T) {
 
 func TestCVESearch(t *testing.T) {
 	Convey("Test image vulenrability scanning", t, func() {
+		updateDuration, _ := time.ParseDuration("1h")
+		expectedDuration, _ := time.ParseDuration("2h")
 		config := api.NewConfig()
 		config.HTTP.Port = SecurePort1
 		htpasswdPath := makeHtpasswdFile()
@@ -476,7 +476,7 @@ func TestCVESearch(t *testing.T) {
 		defer os.RemoveAll(dbDir)
 		c.Config.Storage.RootDirectory = dbDir
 		cveConfig := &api.CVEConfig{
-			UpdateInterval: 2,
+			UpdateInterval: updateDuration,
 		}
 		searchConfig := &api.SearchConfig{
 			CVE: cveConfig,
@@ -507,6 +507,8 @@ func TestCVESearch(t *testing.T) {
 			ctx := context.Background()
 			_ = c.Server.Shutdown(ctx)
 		}()
+
+		So(c.Config.Extensions.Search.CVE.UpdateInterval, ShouldEqual, expectedDuration)
 
 		// without creds, should get access error
 		resp, err := resty.R().Get(BaseURL1 + "/v2/")
@@ -682,54 +684,5 @@ func TestCVESearch(t *testing.T) {
 		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(BaseURL1 + "/query?query={ImageListForCVE(id:\"" + id + "\"){Name%20Tags}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
-	})
-}
-
-func TestCveConfig(t *testing.T) {
-	updateDuration, _ := time.ParseDuration("1h")
-	expectedDuration, _ := time.ParseDuration("2h")
-
-	Convey("Make a new cve config", t, func() {
-		config := api.NewConfig()
-		config.HTTP.Port = SecurePort1
-		cveConfig := &api.CVEConfig{
-			UpdateInterval: updateDuration,
-		}
-		searchConfig := &api.SearchConfig{
-			CVE: cveConfig,
-		}
-		config.Extensions = &api.ExtensionConfig{
-			Search: searchConfig,
-		}
-		c := api.NewController(config)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		c.Config.Storage.RootDirectory = dir
-
-		go func() {
-			// this blocks
-			if err := c.Run(); err != nil {
-				return
-			}
-		}()
-
-		// wait till ready
-		for {
-			_, err := resty.R().Get(BaseURL1)
-			if err == nil {
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-
-		So(c.Config.Extensions.Search.CVE.UpdateInterval, ShouldEqual, expectedDuration)
-
-		defer func() {
-			ctx := context.Background()
-			_ = c.Server.Shutdown(ctx)
-		}()
 	})
 }


### PR DESCRIPTION
The storage layer is protected with read-write locks.
However, we may be holding the locks over unnecessarily large critical
sections.

The typical workflow is that a blob is first uploaded via a per-client
private session-id meaning the blob is not publicly visible yet. When
the blob being uploaded is very large, the transfer takes a long time
while holding the lock.

Private session-id based uploads don't really need locks, and hold locks
only when blobs are published after the upload is complete.

Note:- 
1. commit: "test: minimize trivy db download tests to avoid api rate limit" added to avoid api rate limit during build process.
2. Since I added multiple parallel request tests now, make test is taking longer time to execute and that's why we need to add wait during make process also in travis, commit: "build: add wait time during travis make build process" serve this purpose. 
