### PR TITLE
Raise error when adding a new zot config with an existed saved name

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -36,4 +36,5 @@ var (
 	ErrIllegalConfigKey        = errors.New("cli: given config key is not allowed")
 	ErrScanNotSupported        = errors.New("search: scanning of image media type not supported")
 	ErrCLITimeout              = errors.New("cli: Query timed out while waiting for results")
+	ErrDuplicateConfigName     = errors.New("cli: cli config name already added")
 )

--- a/pkg/cli/config_cmd.go
+++ b/pkg/cli/config_cmd.go
@@ -204,6 +204,10 @@ func addConfig(configPath, configName, url string) error {
 		return zotErrors.ErrInvalidURL
 	}
 
+	if configNameExists(configs, configName) {
+		return zotErrors.ErrDuplicateConfigName
+	}
+
 	configMap := make(map[string]interface{})
 	configMap["url"] = url
 	configMap[nameKey] = configName
@@ -359,6 +363,17 @@ func getAllConfig(configPath, configName string) (string, error) {
 	}
 
 	return "", zotErrors.ErrConfigNotFound
+}
+
+func configNameExists(configs []interface{}, configName string) bool {
+	for _, val := range configs {
+		configMap := val.(map[string]interface{})
+		if configMap[nameKey] == configName {
+			return true
+		}
+	}
+
+	return false
 }
 
 const (

--- a/pkg/cli/config_cmd_test.go
+++ b/pkg/cli/config_cmd_test.go
@@ -300,4 +300,18 @@ func TestConfigCmdMain(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(buff.String(), ShouldContainSubstring, "cannot reset")
 	})
+
+	Convey("Test add a config with an existing saved name", t, func() {
+		args := []string{"add", "configtest", "https://test-url.com/new"}
+		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
+		defer os.Remove(configPath)
+		cmd := NewConfigCommand()
+		buff := bytes.NewBufferString("")
+		cmd.SetOut(buff)
+		cmd.SetErr(ioutil.Discard)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		So(err, ShouldNotBeNil)
+		So(buff.String(), ShouldContainSubstring, "cli config name already added")
+	})
 }


### PR DESCRIPTION
This PR should fix error:


```
$ zot config -l
$ zot config add main https://test-url.com
$ zot config -l
main    https://test-url.com
$ zot config add main https://test-url.com
$ zot config -l
main    https://test-url.com
main    https://test-url.com
```

Fix:

```
$ ./bin/zot config -l
$ ./bin/zot config add main https://test-url.com
$ ./bin/zot config -l
main    https://test-url.com
$ ./bin/zot config add main https://test-url.com
Error: config: config name is used. see 'zot config -l'
Usage:
  zot config add <config-name> <url> [flags]

Flags:
  -h, --help   help for add

Useful variables:
  url           zot server URL
  showspinner   show spinner while loading data [true/false]
  verify-tls    verify TLS Certificate verification of the server [default: true]

```

closes: #150 