### PR TITLE
dedupe: optimize check-blob with hard links

### DIFF
--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -501,7 +501,7 @@ func TestCVESearch(t *testing.T) {
 		}
 
 		// Wait for trivy db to download
-		time.Sleep(35 * time.Second)
+		time.Sleep(45 * time.Second)
 
 		defer func() {
 			ctx := context.Background()

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -518,7 +518,8 @@ func TestNegativeCases(t *testing.T) {
 		err = os.Chmod(dir, 0000) // remove all perms
 		So(err, ShouldBeNil)
 		if os.Geteuid() != 0 {
-			So(func() { _ = il.InitRepo("test") }, ShouldPanic)
+			err = il.InitRepo("test")
+			So(err, ShouldNotBeNil)
 		}
 	})
 


### PR DESCRIPTION
In use cases, when there are large images with shared layers across
repositories, clients may benefit from not re-uploading the same blobs
over and over again.

We ensure this by hard linking when check-blob api is called.

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>