### PR TITLE
ci/cd: changed distrbution spec branch to main from master

### DIFF
--- a/.github/workflows/oci-conformance-action.yml
+++ b/.github/workflows/oci-conformance-action.yml
@@ -38,7 +38,7 @@ jobs:
           docker build -f ./Dockerfile-conformance -t "${ZOT_REF}" .
           docker run --rm -p 5000:5000 -v "$(pwd)":/go/src/github.com/anuvu/zot -idt "${ZOT_REF}"
     - name: Run OCI Distribution Spec conformance tests
-      uses: opencontainers/distribution-spec@master
+      uses: opencontainers/distribution-spec@main
       env:
         OCI_ROOT_URL: ${{ env.ZOT_URL }}
         OCI_NAMESPACE: oci-conformance/distribution-test


### PR DESCRIPTION
Previously conformance github action was failing because it was pointing to invalid branch of distribution-spec repo, changed github action to point it to correct one. 