### PR TITLE
api: use blob cache path while making hard link

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -497,9 +497,7 @@ func (rh *RouteHandler) CheckBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mediaType := r.Header.Get("Accept")
-
-	ok, blen, err := is.CheckBlob(name, digest, mediaType)
+	ok, blen, err := is.CheckBlob(name, digest)
 	if err != nil {
 		switch err {
 		case errors.ErrBadBlobDigest:
@@ -662,8 +660,10 @@ func (rh *RouteHandler) CreateBlobUpload(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		// zot does not support cross mounting directly and do a workaround by copying blob using hard link
-		err := is.MountBlob(name, from[0], mountDigests[0])
+		// zot does not support cross mounting directly and do a workaround creating using hard link.
+		// check blob looks for actual path (name+mountDigests[0]) first then look for cache and
+		// if found in cache, will do hard link and if fails we will start new upload.
+		_, _, err := is.CheckBlob(name, mountDigests[0])
 		if err != nil {
 			u, err := is.NewBlobUpload(name)
 			if err != nil {

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -102,7 +102,7 @@ func TestAPIs(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(b, ShouldEqual, l)
 
-				_, _, err = il.CheckBlob("test", d.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+				_, _, err = il.CheckBlob("test", d.String())
 				So(err, ShouldBeNil)
 
 				_, _, err = il.GetBlob("test", d.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
@@ -201,7 +201,7 @@ func TestAPIs(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(b, ShouldEqual, l)
 
-				_, _, err = il.CheckBlob("test", d.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+				_, _, err = il.CheckBlob("test", d.String())
 				So(err, ShouldBeNil)
 
 				_, _, err = il.GetBlob("test", d.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
@@ -363,7 +363,7 @@ func TestAPIs(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(b, ShouldEqual, l)
 
-			_, _, err = il.CheckBlob("dedupe1", d.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+			_, _, err = il.CheckBlob("dedupe1", d.String())
 			So(err, ShouldBeNil)
 
 			_, _, err = il.GetBlob("dedupe1", d.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
@@ -412,7 +412,7 @@ func TestAPIs(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(b, ShouldEqual, l)
 
-			_, _, err = il.CheckBlob("dedupe2", d.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+			_, _, err = il.CheckBlob("dedupe2", d.String())
 			So(err, ShouldBeNil)
 
 			_, _, err = il.GetBlob("dedupe2", d.String(), "application/vnd.oci.image.layer.v1.tar+gzip")


### PR DESCRIPTION
previously mount blob will look for blob that is provided in http request and try to hard link that path but ideally we should look for path from ourcache and do the hard link of that particular path, this commit does the same.