### PR TITLE
authn: serialize ldap authn calls

### DIFF
--- a/pkg/api/authz.go
+++ b/pkg/api/authz.go
@@ -14,13 +14,13 @@ import (
 type contextKey int
 
 const (
-	// actions
+	// actions.
 	CREATE = "create"
 	READ   = "read"
 	UPDATE = "update"
 	DELETE = "delete"
 
-	// request-local context key
+	// request-local context key.
 	authzCtxKey contextKey = 0
 )
 

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -943,7 +943,6 @@ func (rh *RouteHandler) PatchBlobUpload(w http.ResponseWriter, r *http.Request) 
 // @Failure 500 {string} string "internal server error"
 // @Router /v2/{name}/blobs/uploads/{session_id} [put].
 func (rh *RouteHandler) UpdateBlobUpload(w http.ResponseWriter, r *http.Request) {
-	rh.c.Log.Info().Interface("headers", r.Header).Msg("HEADERS")
 	vars := mux.Vars(r)
 	name, ok := vars["name"]
 


### PR DESCRIPTION
Some LDAP servers are not MT-safe in that when searches happen with binds
in flight leads to errors such as:
"comment: No other operations may be performed on the connection while a
bind is outstanding"

Add goroutine-id in logs to help debug MT bugs.

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

Fixes issue #224 