### PR TITLE
sync: copy to a local cache first instead of writing over http

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,7 @@ Examples of working configurations for various use cases are available [here](..
 * [Identity-based Authorization](#identity-based-authorization)
 * [Logging](#logging)
 * [Metrics](#metrics)
+* [Sync](#sync)
 
 
 ## Network
@@ -335,4 +336,63 @@ AWS_PROFILE=test-account
 For more details see https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
 
 
+
+## Sync
+
+Enable and configure sync with:
+
+```
+		"sync": {
+```
+
+Configure credentials for upstream registries:
+
+```
+			"credentialsFile": "./examples/sync-auth-filepath.json",
+```
+
+Configure each registry sync:
+
+```
+			"registries": [{
+				"url": "https://registry1:5000",
+				"onDemand": false,                  # pull any image which the local registry doesn't have
+				"pollInterval": "6h",               # polling interval
+				"tlsVerify": true,                  # wheather or not to verify tls
+				"certDir": "/home/user/certs",      # use certificates at certDir path, if not specified then use the default certs dir
+				"content":[                         # which content to periodically pull
+					{
+						"prefix":"/repo1/repo",         # pull all images under /repo1/repo
+						"tags":{                        # filter by tags
+							"regex":"4.*",                # filter tags by regex
+							"semver":true                 # filter tags by semver compliance
+						}
+					},
+					{
+						"prefix":"/repo2/repo"          # pull all images under /repo2/repo
+					}
+				]
+			},
+			{
+				"url": "https://registry2:5000",
+				"pollInterval": "12h",
+				"tlsVerify": false,
+				"onDemand": false,
+				"content":[
+					{
+						"prefix":"/repo2",
+						"tags":{
+							"semver":true
+						}
+					}
+				]
+			},
+			{
+				"url": "https://docker.io/library",
+				"onDemand": true,                   # doesn't have content, don't periodically pull, pull just on demand.
+				"tlsVerify": true
+			}
+		]
+		}
+```
 

--- a/examples/config-sync.json
+++ b/examples/config-sync.json
@@ -5,7 +5,7 @@
 	},
 	"http":{
 		"address":"127.0.0.1",
-		"port":"5000"
+		"port":"8080"
 	},
 	"log":{
 		"level":"debug"

--- a/examples/sync-auth-filepath.json
+++ b/examples/sync-auth-filepath.json
@@ -1,5 +1,5 @@
 {
-    "localhost:8080": {
+    "127.0.0.1:8080": {
         "username": "user",
         "password": "pass"
     },

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -137,6 +137,10 @@ func (c *Controller) Run() error {
 		// Enable extensions if extension config is provided
 		if c.Config != nil && c.Config.Extensions != nil {
 			ext.EnableExtensions(c.Config, c.Log, c.Config.Storage.RootDirectory)
+
+			if c.Config.Extensions.Sync != nil {
+				ext.EnableSyncExtension(c.Config, c.Log, c.StoreController)
+			}
 		}
 	} else {
 		// we can't proceed without global storage

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1263,30 +1263,24 @@ func getImageManifest(rh *RouteHandler, is storage.ImageStore, name,
 		case errors.ErrRepoNotFound:
 			if rh.c.Config.Extensions != nil && rh.c.Config.Extensions.Sync != nil {
 				rh.c.Log.Info().Msgf("image not found, trying to get image %s:%s by syncing on demand", name, reference)
-				ok, errSync := ext.SyncOneImage(rh.c.Config, rh.c.Log, name, reference)
 
-				switch ok {
-				case true:
+				errSync := ext.SyncOneImage(rh.c.Config, rh.c.Log, rh.c.StoreController, name, reference)
+				if errSync != nil {
+					rh.c.Log.Err(errSync).Msgf("error encounter while syncing image %s:%s", name, reference)
+				} else {
 					content, digest, mediaType, err = is.GetImageManifest(name, reference)
-				case false && errSync == nil:
-					rh.c.Log.Info().Msgf("couldn't find image %s:%s in sync registries", name, reference)
-				case false && errSync != nil:
-					rh.c.Log.Err(err).Msgf("error encounter while syncing image %s:%s", name, reference)
 				}
 			}
 
 		case errors.ErrManifestNotFound:
 			if rh.c.Config.Extensions != nil && rh.c.Config.Extensions.Sync != nil {
 				rh.c.Log.Info().Msgf("manifest not found, trying to get image %s:%s by syncing on demand", name, reference)
-				ok, errSync := ext.SyncOneImage(rh.c.Config, rh.c.Log, name, reference)
 
-				switch ok {
-				case true:
+				errSync := ext.SyncOneImage(rh.c.Config, rh.c.Log, rh.c.StoreController, name, reference)
+				if errSync != nil {
+					rh.c.Log.Err(errSync).Msgf("error encounter while syncing image %s:%s", name, reference)
+				} else {
 					content, digest, mediaType, err = is.GetImageManifest(name, reference)
-				case false && errSync == nil:
-					rh.c.Log.Info().Msgf("couldn't find image %s:%s in sync registries", name, reference)
-				case false && errSync != nil:
-					rh.c.Log.Err(err).Msgf("error encounter while syncing image %s:%s", name, reference)
 				}
 			}
 		default:

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -174,10 +174,16 @@ func LoadConfiguration(config *config.Config, configPath string) {
 		}
 	}
 
-	// enforce s3 driver in case of using storage driver
 	if len(config.Storage.StorageDriver) != 0 {
+		// enforce s3 driver in case of using storage driver
 		if config.Storage.StorageDriver["name"] != storage.S3StorageDriverName {
 			log.Error().Err(errors.ErrBadConfig).Msgf("unsupported storage driver: %s", config.Storage.StorageDriver["name"])
+			panic(errors.ErrBadConfig)
+		}
+
+		// enforce filesystem storage in case sync feature is enabled
+		if config.Extensions != nil && config.Extensions.Sync != nil {
+			log.Error().Err(errors.ErrBadConfig).Msg("sync supports only filesystem storage")
 			panic(errors.ErrBadConfig)
 		}
 	}

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -118,6 +118,22 @@ func TestVerify(t *testing.T) {
 		So(func() { _ = cli.NewRootCmd().Execute() }, ShouldNotPanic)
 	})
 
+	Convey("Test verify w/ sync and w/o filesystem storage", t, func(c C) {
+		tmpfile, err := ioutil.TempFile("", "zot-test*.json")
+		So(err, ShouldBeNil)
+		defer os.Remove(tmpfile.Name()) // clean up
+		content := []byte(`{"storage":{"rootDirectory":"/tmp/zot", "storageDriver": {"name": "s3"}},
+							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+							"extensions":{"sync": {"registries": [{"url":"localhost:9999"}]}}}`)
+		_, err = tmpfile.Write(content)
+		So(err, ShouldBeNil)
+		err = tmpfile.Close()
+		So(err, ShouldBeNil)
+		os.Args = []string{"cli_test", "verify", tmpfile.Name()}
+		So(func() { _ = cli.NewRootCmd().Execute() }, ShouldPanic)
+	})
+
 	Convey("Test verify good config", t, func(c C) {
 		tmpfile, err := ioutil.TempFile("", "zot-test*.json")
 		So(err, ShouldBeNil)

--- a/pkg/extensions/minimal.go
+++ b/pkg/extensions/minimal.go
@@ -22,15 +22,22 @@ func EnableExtensions(config *config.Config, log log.Logger, rootDir string) {
 		"any extensions, please build zot full binary for this feature")
 }
 
+// EnableSyncExtension ...
+func EnableSyncExtension(config *config.Config, log log.Logger, storeController storage.StoreController) {
+	log.Warn().Msg("skipping enabling sync extension because given zot binary doesn't support any extensions," +
+		"please build zot full binary for this feature")
+}
+
 // SetupRoutes ...
 func SetupRoutes(conf *config.Config, router *mux.Router, storeController storage.StoreController, log log.Logger) {
 	log.Warn().Msg("skipping setting up extensions routes because given zot binary doesn't support " +
 		"any extensions, please build zot full binary for this feature")
 }
 
-// SyncOneImage...
-func SyncOneImage(config *config.Config, log log.Logger, repoName, reference string) (bool, error) {
-	log.Warn().Msg("skipping syncing on demand because given zot binary doesn't support " +
-		"any extensions, please build zot full binary for this feature")
-	return false, nil
+// SyncOneImage ...
+func SyncOneImage(config *config.Config, log log.Logger, storeController storage.StoreController,
+	repoName, reference string) error {
+	log.Warn().Msg("skipping syncing on demand because given zot binary doesn't support any extensions," +
+		"please build zot full binary for this feature")
+	return nil
 }

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -2,16 +2,25 @@ package sync
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
+	"path"
 	"testing"
 	"time"
 
 	"github.com/anuvu/zot/errors"
+	"github.com/anuvu/zot/pkg/extensions/monitoring"
 	"github.com/anuvu/zot/pkg/log"
+	"github.com/anuvu/zot/pkg/storage"
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
+	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/rs/zerolog"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -27,8 +36,53 @@ const (
 	host = "127.0.0.1:45117"
 )
 
+func copyFiles(sourceDir string, destDir string) error {
+	sourceMeta, err := os.Stat(sourceDir)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(destDir, sourceMeta.Mode()); err != nil {
+		return err
+	}
+
+	files, err := ioutil.ReadDir(sourceDir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		sourceFilePath := path.Join(sourceDir, file.Name())
+		destFilePath := path.Join(destDir, file.Name())
+
+		if file.IsDir() {
+			if err = copyFiles(sourceFilePath, destFilePath); err != nil {
+				return err
+			}
+		} else {
+			sourceFile, err := os.Open(sourceFilePath)
+			if err != nil {
+				return err
+			}
+			defer sourceFile.Close()
+
+			destFile, err := os.Create(destFilePath)
+			if err != nil {
+				return err
+			}
+			defer destFile.Close()
+
+			if _, err = io.Copy(destFile, sourceFile); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 func TestSyncInternal(t *testing.T) {
-	Convey("test parseRepositoryReference func", t, func() {
+	Convey("Verify parseRepositoryReference func", t, func() {
 		repositoryReference := fmt.Sprintf("%s/%s", host, testImage)
 		ref, err := parseRepositoryReference(repositoryReference)
 		So(err, ShouldBeNil)
@@ -64,25 +118,20 @@ func TestSyncInternal(t *testing.T) {
 
 		srcCtx := &types.SystemContext{}
 		_, err = getImageTags(context.Background(), srcCtx, ref)
-
 		So(err, ShouldNotBeNil)
 
-		_, _, err = getLocalContexts("inexistent.cert", "inexistent.key", "inexistent.crt", log.NewLogger("", ""))
-		So(err, ShouldNotBeNil)
-
-		_, _, err = getLocalContexts(ServerCert, "inexistent.key", "inexistent.crt", log.NewLogger("", ""))
-		So(err, ShouldNotBeNil)
-
-		_, _, err = getLocalContexts(ServerCert, ServerKey, "inexistent.crt", log.NewLogger("", ""))
-		So(err, ShouldNotBeNil)
-
-		taggedRef, err := reference.WithTag(ref, testImageTag)
+		taggedRef, err := reference.WithTag(ref, "tag")
 		So(err, ShouldBeNil)
+
+		_, err = getImageTags(context.Background(), &types.SystemContext{}, taggedRef)
+		So(err, ShouldNotBeNil)
 
 		dockerRef, err := docker.NewReference(taggedRef)
 		So(err, ShouldBeNil)
 
-		So(getTagFromRef(dockerRef, log.NewLogger("", "")), ShouldNotBeNil)
+		//tag := getTagFromRef(dockerRef, log.NewLogger("", ""))
+
+		So(getTagFromRef(dockerRef, log.NewLogger("debug", "")), ShouldNotBeNil)
 
 		var tlsVerify bool
 		updateDuration := time.Microsecond
@@ -100,10 +149,176 @@ func TestSyncInternal(t *testing.T) {
 
 		cfg := Config{Registries: []RegistryConfig{syncRegistryConfig}, CredentialsFile: "/invalid/path/to/file"}
 
-		So(Run(cfg, log.NewLogger("", ""),
-			"127.0.0.1", "5000", ServerCert, ServerKey, CACert), ShouldNotBeNil)
+		So(Run(cfg, storage.StoreController{}, log.NewLogger("debug", "")), ShouldNotBeNil)
 
 		_, err = getFileCredentials("/invalid/path/to/file")
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Test getUpstreamCatalog() with missing certs", t, func() {
+		var tlsVerify bool
+		updateDuration := time.Microsecond
+		syncRegistryConfig := RegistryConfig{
+			Content: []Content{
+				{
+					Prefix: testImage,
+				},
+			},
+			URL:          BaseURL,
+			PollInterval: updateDuration,
+			TLSVerify:    &tlsVerify,
+			CertDir:      "/tmp/missing_certs/a/b/c/d/z",
+		}
+
+		_, err := getUpstreamCatalog(&syncRegistryConfig, Credentials{}, log.NewLogger("debug", ""))
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Test getUpstreamCatalog() with bad certs", t, func() {
+		badCertsDir, err := ioutil.TempDir("", "bad_certs*")
+		if err != nil {
+			panic(err)
+		}
+
+		if err := os.WriteFile(path.Join(badCertsDir, "ca.crt"), []byte("certificate"), 0755); err != nil {
+			panic(err)
+		}
+
+		defer os.RemoveAll(badCertsDir)
+
+		var tlsVerify bool
+		updateDuration := time.Microsecond
+		syncRegistryConfig := RegistryConfig{
+			Content: []Content{
+				{
+					Prefix: testImage,
+				},
+			},
+			URL:          BaseURL,
+			PollInterval: updateDuration,
+			TLSVerify:    &tlsVerify,
+			CertDir:      badCertsDir,
+		}
+
+		_, err = getUpstreamCatalog(&syncRegistryConfig, Credentials{}, log.NewLogger("debug", ""))
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Test imagesToCopyFromUpstream()", t, func() {
+		repos := []string{"repo1"}
+		upstreamCtx := &types.SystemContext{}
+
+		_, err := imagesToCopyFromUpstream("localhost:4566", repos, upstreamCtx, Content{}, log.NewLogger("debug", ""))
+		So(err, ShouldNotBeNil)
+
+		_, err = imagesToCopyFromUpstream("docker://localhost:4566", repos, upstreamCtx,
+			Content{}, log.NewLogger("debug", ""))
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Verify pushSyncedLocalImage func", t, func() {
+		storageDir, err := ioutil.TempDir("", "oci-dest-repo-test")
+		if err != nil {
+			panic(err)
+		}
+
+		defer os.RemoveAll(storageDir)
+
+		log := log.Logger{Logger: zerolog.New(os.Stdout)}
+		metrics := monitoring.NewMetricsServer(false, log)
+
+		imageStore := storage.NewImageStore(storageDir, false, false, log, metrics)
+
+		storeController := storage.StoreController{}
+		storeController.DefaultStore = imageStore
+
+		err = pushSyncedLocalImage(testImage, testImageTag, "", storeController, log)
+		So(err, ShouldNotBeNil)
+
+		testRootDir := path.Join(imageStore.RootDir(), testImage, SyncBlobUploadDir)
+		//testImagePath := path.Join(testRootDir, testImage)
+
+		err = os.MkdirAll(testRootDir, 0755)
+		if err != nil {
+			panic(err)
+		}
+
+		err = copyFiles("../../../test/data", testRootDir)
+		if err != nil {
+			panic(err)
+		}
+
+		testImageStore := storage.NewImageStore(testRootDir, false, false, log, metrics)
+		manifestContent, _, _, err := testImageStore.GetImageManifest(testImage, testImageTag)
+		So(err, ShouldBeNil)
+
+		var manifest ispec.Manifest
+
+		if err := json.Unmarshal(manifestContent, &manifest); err != nil {
+			panic(err)
+		}
+
+		if err := os.Chmod(storageDir, 0000); err != nil {
+			panic(err)
+		}
+
+		if os.Geteuid() != 0 {
+			So(func() {
+				_ = pushSyncedLocalImage(testImage, testImageTag, "", storeController, log)
+			},
+				ShouldPanic)
+		}
+
+		if err := os.Chmod(storageDir, 0755); err != nil {
+			panic(err)
+		}
+
+		if err := os.Chmod(path.Join(testRootDir, testImage, "blobs", "sha256",
+			manifest.Layers[0].Digest.Hex()), 0000); err != nil {
+			panic(err)
+		}
+
+		err = pushSyncedLocalImage(testImage, testImageTag, "", storeController, log)
+		So(err, ShouldNotBeNil)
+
+		if err := os.Chmod(path.Join(testRootDir, testImage, "blobs", "sha256",
+			manifest.Layers[0].Digest.Hex()), 0755); err != nil {
+			panic(err)
+		}
+
+		cachedManifestConfigPath := path.Join(imageStore.RootDir(), testImage, SyncBlobUploadDir,
+			testImage, "blobs", "sha256", manifest.Config.Digest.Hex())
+		if err := os.Chmod(cachedManifestConfigPath, 0000); err != nil {
+			panic(err)
+		}
+
+		err = pushSyncedLocalImage(testImage, testImageTag, "", storeController, log)
+		So(err, ShouldNotBeNil)
+
+		if err := os.Chmod(cachedManifestConfigPath, 0755); err != nil {
+			panic(err)
+		}
+
+		manifestConfigPath := path.Join(imageStore.RootDir(), testImage, "blobs", "sha256", manifest.Config.Digest.Hex())
+		if err := os.MkdirAll(manifestConfigPath, 0000); err != nil {
+			panic(err)
+		}
+
+		err = pushSyncedLocalImage(testImage, testImageTag, "", storeController, log)
+		So(err, ShouldNotBeNil)
+
+		if err := os.Remove(manifestConfigPath); err != nil {
+			panic(err)
+		}
+
+		mDigest := godigest.FromBytes(manifestContent)
+
+		manifestPath := path.Join(imageStore.RootDir(), testImage, "blobs", mDigest.Algorithm().String(), mDigest.Encoded())
+		if err := os.MkdirAll(manifestPath, 0000); err != nil {
+			panic(err)
+		}
+
+		err = pushSyncedLocalImage(testImage, testImageTag, "", storeController, log)
 		So(err, ShouldNotBeNil)
 	})
 }


### PR DESCRIPTION
Summary:

- fixed https://github.com/anuvu/zot/issues/266
- Added sync Readme
- Accept all images with or without signatures, for more details see: https://www.mankier.com/5/containers-policy.json, removed the need of /etc/containers/policy.json file
- Fixed sync switch statement in routes
- Fixed enabling sync with multiple storage subpaths.
