### PR TITLE
Fix data races in tests, closes #255

### DIFF
--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	zotErrors "github.com/anuvu/zot/errors"
+	"github.com/anuvu/zot/pkg/storage"
 )
 
 var httpClientsMap = make(map[string]*http.Client) //nolint: gochecknoglobals
@@ -141,7 +142,7 @@ func loadPerHostCerts(caCertPool *x509.CertPool, host string) *tls.Config {
 	home := os.Getenv("HOME")
 	clientCertsDir := filepath.Join(home, homeCertsDir, host)
 
-	if dirExists(clientCertsDir) {
+	if storage.DirExists(clientCertsDir) {
 		tlsConfig, err := getTLSConfig(clientCertsDir, caCertPool)
 
 		if err == nil {
@@ -151,7 +152,7 @@ func loadPerHostCerts(caCertPool *x509.CertPool, host string) *tls.Config {
 
 	// Check if the /etc/containers/certs.d/$IP:$PORT dir exists
 	clientCertsDir = filepath.Join(certsPath, host)
-	if dirExists(clientCertsDir) {
+	if storage.DirExists(clientCertsDir) {
 		tlsConfig, err := getTLSConfig(clientCertsDir, caCertPool)
 
 		if err == nil {
@@ -183,19 +184,6 @@ func getTLSConfig(certsPath string, caCertPool *x509.CertPool) (*tls.Config, err
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,
 	}, nil
-}
-
-func dirExists(d string) bool {
-	fi, err := os.Stat(d)
-	if err != nil && os.IsNotExist(err) {
-		return false
-	}
-
-	if !fi.IsDir() {
-		return false
-	}
-
-	return true
 }
 
 func isURL(str string) bool {

--- a/pkg/cli/cve_cmd_test.go
+++ b/pkg/cli/cve_cmd_test.go
@@ -18,9 +18,9 @@ import (
 	"github.com/anuvu/zot/pkg/api"
 	"github.com/anuvu/zot/pkg/api/config"
 	extconf "github.com/anuvu/zot/pkg/extensions/config"
-	"gopkg.in/resty.v1"
-
+	. "github.com/anuvu/zot/test"
 	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/resty.v1"
 )
 
 func TestSearchCVECmd(t *testing.T) {
@@ -285,8 +285,8 @@ func TestSearchCVECmd(t *testing.T) {
 }
 
 func TestServerCVEResponse(t *testing.T) {
-	port := getFreePort()
-	url := getBaseURL(port)
+	port := GetFreePort()
+	url := GetBaseURL(port)
 	conf := config.New()
 	conf.HTTP.Port = port
 	c := api.NewController(conf)
@@ -296,7 +296,7 @@ func TestServerCVEResponse(t *testing.T) {
 		panic(err)
 	}
 
-	err = copyFiles("../../test/data/zot-cve-test", path.Join(dir, "zot-cve-test"))
+	err = CopyFiles("../../test/data/zot-cve-test", path.Join(dir, "zot-cve-test"))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -13,39 +13,19 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-
-	"gopkg.in/resty.v1"
-
 	"testing"
 	"time"
 
 	zotErrors "github.com/anuvu/zot/errors"
 	"github.com/anuvu/zot/pkg/api"
 	"github.com/anuvu/zot/pkg/api/config"
-	"github.com/anuvu/zot/pkg/compliance/v1_0_0"
 	extconf "github.com/anuvu/zot/pkg/extensions/config"
+	. "github.com/anuvu/zot/test"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/phayes/freeport"
 	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/resty.v1"
 )
-
-const (
-	BaseURL = "http://127.0.0.1:%s"
-)
-
-func getBaseURL(port string) string {
-	return fmt.Sprintf(BaseURL, port)
-}
-
-func getFreePort() string {
-	port, err := freeport.GetFreePort()
-	if err != nil {
-		panic(err)
-	}
-
-	return fmt.Sprint(port)
-}
 
 func TestSearchImageCmd(t *testing.T) {
 	Convey("Test image help", t, func() {
@@ -301,8 +281,8 @@ func TestOutputFormat(t *testing.T) {
 
 func TestServerResponse(t *testing.T) {
 	Convey("Test from real server", t, func() {
-		port := getFreePort()
-		url := getBaseURL(port)
+		port := GetFreePort()
+		url := GetBaseURL(port)
 		conf := config.New()
 		conf.HTTP.Port = port
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -481,7 +461,7 @@ func TestServerResponse(t *testing.T) {
 func uploadManifest(url string) {
 	// create a blob/layer
 	resp, _ := resty.R().Post(url + "/v2/repo7/blobs/uploads/")
-	loc := v1_0_0.Location(url, resp)
+	loc := Location(url, resp)
 
 	content := []byte("this is a blob5")
 	digest := godigest.FromBytes(content)

--- a/pkg/compliance/v1_0_0/check.go
+++ b/pkg/compliance/v1_0_0/check.go
@@ -13,26 +13,13 @@ import (
 
 	"github.com/anuvu/zot/pkg/api"
 	"github.com/anuvu/zot/pkg/compliance"
+	. "github.com/anuvu/zot/test" // nolint:golint,stylecheck
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey" // nolint:golint,stylecheck
 	"github.com/smartystreets/goconvey/convey/reporting"
 	"gopkg.in/resty.v1"
 )
-
-func Location(baseURL string, resp *resty.Response) string {
-	// For some API responses, the Location header is set and is supposed to
-	// indicate an opaque value. However, it is not clear if this value is an
-	// absolute URL (https://server:port/v2/...) or just a path (/v2/...)
-	// zot implements the latter as per the spec, but some registries appear to
-	// return the former - this needs to be clarified
-	loc := resp.Header().Get("Location")
-	if loc[0] == '/' {
-		return baseURL + loc
-	}
-
-	return loc
-}
 
 func CheckWorkflows(t *testing.T, config *compliance.Config) {
 	if config == nil || config.Address == "" || config.Port == "" {

--- a/pkg/exporter/api/controller_test.go
+++ b/pkg/exporter/api/controller_test.go
@@ -19,8 +19,8 @@ import (
 	zotcfg "github.com/anuvu/zot/pkg/api/config"
 	"github.com/anuvu/zot/pkg/exporter/api"
 	"github.com/anuvu/zot/pkg/extensions/monitoring"
+	. "github.com/anuvu/zot/test"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/phayes/freeport"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	. "github.com/smartystreets/goconvey/convey"
@@ -28,7 +28,6 @@ import (
 )
 
 const (
-	BaseURL             = "http://127.0.0.1:%s"
 	SleepTime           = 50 * time.Millisecond
 	SecondToNanoseconds = 1000000000
 )
@@ -40,15 +39,6 @@ func getRandomLatencyN(maxNanoSeconds int64) time.Duration {
 
 func getRandomLatency() time.Duration {
 	return getRandomLatencyN(120 * SecondToNanoseconds) // a random latency (in nanoseconds) that can be up to 2 minutes
-}
-
-func getFreePort() string {
-	port, err := freeport.GetFreePort()
-	if err != nil {
-		panic(err)
-	}
-
-	return fmt.Sprint(port)
 }
 
 func TestNew(t *testing.T) {
@@ -91,8 +81,8 @@ func TestNewExporter(t *testing.T) {
 	Convey("Make an exporter controller", t, func() {
 		exporterConfig := api.DefaultConfig()
 		So(exporterConfig, ShouldNotBeNil)
-		exporterPort := getFreePort()
-		serverPort := getFreePort()
+		exporterPort := GetFreePort()
+		serverPort := GetFreePort()
 		exporterConfig.Exporter.Port = exporterPort
 		dir, _ := ioutil.TempDir("", "metrics")
 		exporterConfig.Exporter.Metrics.Path = strings.TrimPrefix(dir, "/tmp/")

--- a/pkg/storage/storage_fs.go
+++ b/pkg/storage/storage_fs.go
@@ -62,16 +62,7 @@ func (is *ImageStoreFS) RootDir() string {
 }
 
 func (is *ImageStoreFS) DirExists(d string) bool {
-	fi, err := os.Stat(d)
-	if err != nil && os.IsNotExist(err) {
-		return false
-	}
-
-	if !fi.IsDir() {
-		return false
-	}
-
-	return true
+	return DirExists(d)
 }
 
 func getRoutePrefix(name string) string {
@@ -1340,4 +1331,17 @@ func ifOlderThan(is *ImageStoreFS, repo string, delay time.Duration) casext.GCPo
 
 		return true, nil
 	}
+}
+
+func DirExists(d string) bool {
+	fi, err := os.Stat(d)
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+
+	if !fi.IsDir() {
+		return false
+	}
+
+	return true
 }

--- a/pkg/storage/storage_fs_test.go
+++ b/pkg/storage/storage_fs_test.go
@@ -595,7 +595,7 @@ func TestNegativeCases(t *testing.T) {
 		So(err, ShouldNotBeNil)
 	})
 
-	Convey("Invalid dedupe sceanrios", t, func() {
+	Convey("Invalid dedupe scenarios", t, func() {
 		dir, err := ioutil.TempDir("", "oci-repo-test")
 		if err != nil {
 			panic(err)
@@ -670,6 +670,23 @@ func TestNegativeCases(t *testing.T) {
 		err = il.FinishBlobUpload("dedupe2", v, buf, d.String())
 		So(err, ShouldBeNil)
 		So(b, ShouldEqual, l)
+	})
+
+	Convey("DirExists call with a filename as argument", t, func(c C) {
+		dir, err := ioutil.TempDir("", "oci-repo-test")
+		if err != nil {
+			panic(err)
+		}
+		defer os.RemoveAll(dir)
+
+		filePath := path.Join(dir, "file.txt")
+		err = ioutil.WriteFile(filePath, []byte("some dummy file content"), 0644) //nolint: gosec
+		if err != nil {
+			panic(err)
+		}
+
+		ok := storage.DirExists(filePath)
+		So(ok, ShouldBeFalse)
 	})
 }
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -475,6 +475,15 @@ func TestStorageAPIs(t *testing.T) {
 							indexContent, err := il.GetIndexContent("test")
 							So(err, ShouldBeNil)
 
+							if testcase.storageType == "fs" {
+								err = os.Chmod(path.Join(il.RootDir(), "test", "index.json"), 0000)
+								So(err, ShouldBeNil)
+								_, err = il.GetIndexContent("test")
+								So(err, ShouldNotBeNil)
+								err = os.Chmod(path.Join(il.RootDir(), "test", "index.json"), 0644)
+								So(err, ShouldBeNil)
+							}
+
 							var index ispec.Index
 
 							err = json.Unmarshal(indexContent, &index)

--- a/test/common.go
+++ b/test/common.go
@@ -1,0 +1,110 @@
+package test
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/phayes/freeport"
+	"gopkg.in/resty.v1"
+)
+
+const (
+	BaseURL       = "http://127.0.0.1:%s"
+	BaseSecureURL = "https://127.0.0.1:%s"
+)
+
+func GetFreePort() string {
+	port, err := freeport.GetFreePort()
+	if err != nil {
+		panic(err)
+	}
+
+	return fmt.Sprint(port)
+}
+
+func GetBaseURL(port string) string {
+	return fmt.Sprintf(BaseURL, port)
+}
+
+func GetSecureBaseURL(port string) string {
+	return fmt.Sprintf(BaseSecureURL, port)
+}
+
+func MakeHtpasswdFile() string {
+	// bcrypt(username="test", passwd="test")
+	content := "test:$2y$05$hlbSXDp6hzDLu6VwACS39ORvVRpr3OMR4RlJ31jtlaOEGnPjKZI1m\n"
+	return MakeHtpasswdFileFromString(content)
+}
+
+func MakeHtpasswdFileFromString(fileContent string) string {
+	f, err := ioutil.TempFile("", "htpasswd-")
+	if err != nil {
+		panic(err)
+	}
+
+	// bcrypt(username="test", passwd="test")
+	content := []byte(fileContent)
+	if err := ioutil.WriteFile(f.Name(), content, 0600); err != nil {
+		panic(err)
+	}
+
+	return f.Name()
+}
+
+func Location(baseURL string, resp *resty.Response) string {
+	// For some API responses, the Location header is set and is supposed to
+	// indicate an opaque value. However, it is not clear if this value is an
+	// absolute URL (https://server:port/v2/...) or just a path (/v2/...)
+	// zot implements the latter as per the spec, but some registries appear to
+	// return the former - this needs to be clarified
+	loc := resp.Header().Get("Location")
+	return baseURL + loc
+}
+
+func CopyFiles(sourceDir string, destDir string) error {
+	sourceMeta, err := os.Stat(sourceDir)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(destDir, sourceMeta.Mode()); err != nil {
+		return err
+	}
+
+	files, err := ioutil.ReadDir(sourceDir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		sourceFilePath := path.Join(sourceDir, file.Name())
+		destFilePath := path.Join(destDir, file.Name())
+
+		if file.IsDir() {
+			if err = CopyFiles(sourceFilePath, destFilePath); err != nil {
+				return err
+			}
+		} else {
+			sourceFile, err := os.Open(sourceFilePath)
+			if err != nil {
+				return err
+			}
+			defer sourceFile.Close()
+
+			destFile, err := os.Create(destFilePath)
+			if err != nil {
+				return err
+			}
+			defer destFile.Close()
+
+			if _, err = io.Copy(destFile, sourceFile); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/test/common_test.go
+++ b/test/common_test.go
@@ -1,0 +1,81 @@
+// +build extended
+
+package test_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	. "github.com/anuvu/zot/test"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCopyFiles(t *testing.T) {
+	Convey("sourceDir does not exist", t, func() {
+		err := CopyFiles("/path/to/some/unexisting/directory", os.TempDir())
+		So(err, ShouldNotBeNil)
+	})
+	Convey("destDir is a file", t, func() {
+		dir, err := ioutil.TempDir("", "copy-files-test")
+		if err != nil {
+			panic(err)
+		}
+
+		err = CopyFiles("data", dir)
+		if err != nil {
+			panic(err)
+		}
+
+		defer os.RemoveAll(dir)
+		err = CopyFiles(dir, "/etc/passwd")
+		So(err, ShouldNotBeNil)
+	})
+	Convey("sourceDir does not have read permissions", t, func() {
+		dir, err := ioutil.TempDir("", "copy-files-test")
+		if err != nil {
+			panic(err)
+		}
+		defer os.RemoveAll(dir)
+
+		err = os.Chmod(dir, 0300)
+		So(err, ShouldBeNil)
+
+		err = CopyFiles(dir, os.TempDir())
+		So(err, ShouldNotBeNil)
+	})
+	Convey("sourceDir has a subfolder that does not have read permissions", t, func() {
+		dir, err := ioutil.TempDir("", "copy-files-test")
+		if err != nil {
+			panic(err)
+		}
+		defer os.RemoveAll(dir)
+
+		sdir := "subdir"
+		err = os.Mkdir(path.Join(dir, sdir), 0300)
+		So(err, ShouldBeNil)
+
+		err = CopyFiles(dir, os.TempDir())
+		So(err, ShouldNotBeNil)
+	})
+	Convey("sourceDir has a file that does not have read permissions", t, func() {
+		dir, err := ioutil.TempDir("", "copy-files-test")
+		if err != nil {
+			panic(err)
+		}
+		defer os.RemoveAll(dir)
+
+		filePath := path.Join(dir, "file.txt")
+		err = ioutil.WriteFile(filePath, []byte("some dummy file content"), 0644) //nolint: gosec
+		if err != nil {
+			panic(err)
+		}
+
+		err = os.Chmod(filePath, 0300)
+		So(err, ShouldBeNil)
+
+		err = CopyFiles(dir, os.TempDir())
+		So(err, ShouldNotBeNil)
+	})
+}


### PR DESCRIPTION
Signed-off-by: Alexei Dodon <adodon@cisco.com>

Root cause: same port used by controller & shared across different tests that runs in parallel.

