### PR TITLE
sync: skip tls verify on /v2/_catalog when a registry is configured w…

### DIFF
--- a/pkg/extensions/sync/on_demand.go
+++ b/pkg/extensions/sync/on_demand.go
@@ -87,6 +87,8 @@ func OneImage(cfg Config, log log.Logger,
 			return err
 		}
 
+		defer os.RemoveAll(path.Join(imageStore.RootDir(), imageName, SyncBlobUploadDir, uuid.String()))
+
 		localTaggedRepo := fmt.Sprintf("%s:%s", localRepo, tag)
 
 		localRef, err := layout.ParseReference(localTaggedRepo)

--- a/pkg/extensions/sync/sync.go
+++ b/pkg/extensions/sync/sync.go
@@ -106,6 +106,11 @@ func getUpstreamCatalog(regCfg *RegistryConfig, credentials Credentials, log log
 		client.SetCertificates(cert)
 	}
 
+	// nolint: gosec
+	if regCfg.TLSVerify != nil && !*regCfg.TLSVerify {
+		client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	}
+
 	if credentials.Username != "" && credentials.Password != "" {
 		log.Debug().Msgf("sync: using basic auth")
 		client.SetBasicAuth(credentials.Username, credentials.Password)

--- a/pkg/extensions/sync/sync.go
+++ b/pkg/extensions/sync/sync.go
@@ -382,6 +382,8 @@ func syncRegistry(regCfg RegistryConfig, storeController storage.StoreController
 			return err
 		}
 
+		defer os.RemoveAll(path.Join(imageStore.RootDir(), imageName, SyncBlobUploadDir, uuid))
+
 		upstreamTaggedRef := getTagFromRef(upstreamRef, log)
 
 		localTaggedRepo := fmt.Sprintf("%s:%s", localRepo, upstreamTaggedRef.Tag())

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -2105,7 +2105,7 @@ func TestSyncInvalidCerts(t *testing.T) {
 		Convey("Test sync on POST request on /sync", func() {
 			resp, _ := resty.R().Post(destBaseURL + "/sync")
 			So(resp, ShouldNotBeNil)
-			So(string(resp.Body()), ShouldContainSubstring, "signed by unknown authority")
+			So(string(resp.Body()), ShouldContainSubstring, "bad certificate")
 			So(resp.StatusCode(), ShouldEqual, 500)
 		})
 	})


### PR DESCRIPTION
…ith tls-verify false

sync: cleanup the orphaned private download dir on failure, closes 282

Signed-off-by: Petu Eusebiu <peusebiu@cisco.com>
